### PR TITLE
Revamp header navigation and add new pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,8 +7,8 @@ export default function App() {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      {/* Header fijo (h-16): compensamos con pt-16 */}
-      <main className="flex-1 pt-16 md:pt-20">
+      {/* Header fijo (h-20): compensamos con pt-20 */}
+      <main className="flex-1 pt-20 md:pt-24">
         {/* ⛔️ sin wrapper global para permitir secciones full-bleed */}
         <Outlet />
       </main>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,39 +1,68 @@
-// src/components/Header.jsx
-const PRIMARY = "#055a27";
-const SECUNDARY = "#111111ff";
+import { NavLink } from "react-router-dom"
+
+const SECONDARY = "#111111ff"
+
+const NAV_ITEMS = [
+  { to: "/productos", label: "Productos" },
+  { to: "/cursos", label: "Cursos" },
+  { to: "/certificados", label: "Certificados" },
+  { to: "/plataforma", label: "Plataforma" },
+  { to: "/blog", label: "Blog" },
+  { to: "/manuales", label: "Manual de Uso" },
+]
+
+const baseLinkClasses =
+  "inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
 
 export default function Header() {
   return (
-    <header
-      className="fixed top-0 left-0 right-0 z-50 border-b border-white/20 backdrop-blur"
-      style={{ background: "rgba(5, 90, 39, 0.9)" }}
-    >
-      <div className="container-wide h-16 flex items-center justify-between px-4">
-        <a href="/" aria-label="Inicio">
-          <img
-            src={import.meta.env.BASE_URL + "logociviles.png"}
-            alt="Civiles Pro"
-            className="h-10 w-auto"
-          />
-        </a>
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur">
+      <div className="wrap-wide px-4">
+        <div className="flex h-20 items-center gap-6">
+          <a href="/" aria-label="Inicio" className="shrink-0">
+            <img
+              src={import.meta.env.BASE_URL + "logociviles.png"}
+              alt="Civiles Pro"
+              className="h-12 w-auto"
+            />
+          </a>
 
-        {/* Navegación derecha */}
-        <nav className="flex items-center gap-3">
-          <a
-            href="#planes"
-            className="hidden sm:inline text-white/90 hover:text-white"
-          >
-            Ver planes
-          </a>
-          <a
-            href="https://app.civilespro.com/login"
-            className="px-4 py-2 rounded-md font-semibold text-white"
-            style={{ backgroundColor: SECUNDARY }}
-          >
-            Entrar
-          </a>
-        </nav>
+          <nav className="flex-1">
+            <ul className="flex items-center justify-center gap-2 overflow-x-auto">
+              {NAV_ITEMS.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    className={({ isActive }) =>
+                      [
+                        baseLinkClasses,
+                        isActive
+                          ? "bg-primary/10 text-primary"
+                          : "text-gray-600 hover:bg-primary/5 hover:text-primary",
+                      ].join(" ")
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            <NavLink to="/planes" className="btn-outline whitespace-nowrap">
+              Ver planes
+            </NavLink>
+            <NavLink
+              to="/entrar"
+              className="btn"
+              style={{ backgroundColor: SECONDARY, color: "white", borderColor: SECONDARY }}
+            >
+              Entrar
+            </NavLink>
+          </div>
+        </div>
       </div>
     </header>
-  );
+  )
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,15 @@ import { BrowserRouter, Routes, Route } from "react-router-dom"
 import "./index.css"
 import App from "./App.jsx"
 import Home from "./pages/Home.jsx"
+import Productos from "./pages/Productos.jsx"
+import Cursos from "./pages/Cursos.jsx"
+import Certificados from "./pages/Certificados.jsx"
+import Plataforma from "./pages/Plataforma.jsx"
+import Blog from "./pages/Blog.jsx"
+import Manuales from "./pages/Manuales.jsx"
+import Servicios from "./pages/Servicios.jsx"
+import Planes from "./pages/Planes.jsx"
+import Entrar from "./pages/Entrar.jsx"
 import { HelmetProvider } from "react-helmet-async"
 
 ReactDOM.createRoot(document.getElementById("root")).render(
@@ -13,6 +22,15 @@ ReactDOM.createRoot(document.getElementById("root")).render(
         <Routes>
           <Route element={<App />}>
             <Route path="/" element={<Home />} />
+            <Route path="/productos" element={<Productos />} />
+            <Route path="/cursos" element={<Cursos />} />
+            <Route path="/certificados" element={<Certificados />} />
+            <Route path="/plataforma" element={<Plataforma />} />
+            <Route path="/blog" element={<Blog />} />
+            <Route path="/manuales" element={<Manuales />} />
+            <Route path="/servicios" element={<Servicios />} />
+            <Route path="/planes" element={<Planes />} />
+            <Route path="/entrar" element={<Entrar />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default function Blog() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Blog</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Historias, aprendizajes y consejos para gestionar tus proyectos con claridad.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          En breve publicaremos artículos y guías prácticas para tu día a día.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Certificados.jsx
+++ b/src/pages/Certificados.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default function Certificados() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Certificados</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Valida tus habilidades con certificaciones respaldadas por Civiles Pro y la industria.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Próximamente compartiremos los programas de certificación disponibles.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Cursos.jsx
+++ b/src/pages/Cursos.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default function Cursos() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Cursos</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Aprende con guías y programas diseñados por profesionales de la construcción.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Estamos preparando la grilla de cursos en línea y presenciales.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Entrar.jsx
+++ b/src/pages/Entrar.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default function Entrar() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Entrar a Civiles Pro</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Accede con tu cuenta para continuar trabajando en tus proyectos.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Pronto podrás iniciar sesión directamente desde este sitio.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,7 +2,6 @@
 import React from "react"
 import SEO from "../components/SEO.jsx"
 import BimServiceCard from "../components/BimServiceCard.jsx"
-import products from "../data/products.js"
 
 export default function Home() {
   const jsonLd = {
@@ -14,10 +13,10 @@ export default function Home() {
     "sameAs": [
       "https://www.facebook.com/ingcivilespro",
       "https://www.instagram.com/civilespro/",
-      "https://www.tiktok.com/@ingcivilespro"
+      "https://www.tiktok.com/@ingcivilespro",
     ],
     "description":
-      "Comunidad de ingenieros, arquitectos y maestros de obra. Calcula materiales, genera presupuestos con APU y exporta a Excel."
+      "Comunidad de ingenieros, arquitectos y maestros de obra. Calcula materiales, genera presupuestos con APU y exporta a Excel.",
   }
 
   return (
@@ -36,12 +35,15 @@ export default function Home() {
             Somos una comunidad de la construcción
           </h1>
           <p className="mt-5 mx-auto max-w-2xl text-lg text-gray-700">
-            Ingenieros, arquitectos y maestros de obra compartiendo recursos,
-            plantillas y herramientas para que tu obra sea más <b>rápida</b> y <b>confiable</b>.
+            Ingenieros, arquitectos y maestros de obra compartiendo recursos, plantillas y herramientas para que tu obra sea más <b>rápida</b> y <b>confiable</b>.
           </p>
           <div className="mt-8 flex gap-3 justify-center">
-            <a href="/manuales" className="btn-primary">Ver manuales</a>
-            <a href="/blog" className="btn-outline">Leer blog</a>
+            <a href="/manuales" className="btn-primary">
+              Ver manuales
+            </a>
+            <a href="/blog" className="btn-outline">
+              Leer blog
+            </a>
           </div>
         </div>
       </section>
@@ -49,38 +51,18 @@ export default function Home() {
       {/* SERVICIOS */}
       <section id="servicios" className="bg-gray-50 py-16">
         <div className="wrap-wide px-4">
-            <h2 className="text-2xl md:text-3xl font-bold">Servicios</h2>
-            <p className="mt-2 text-gray-700">Te acompañamos en todas las etapas del proyecto.</p>
+          <h2 className="text-2xl md:text-3xl font-bold">Servicios</h2>
+          <p className="mt-2 text-gray-700">Te acompañamos en todas las etapas del proyecto.</p>
 
-            {/* Tarjeta hero de Modelado BIM */}
-            <div className="mt-8">
+          {/* Tarjeta hero de Modelado BIM */}
+          <div className="mt-8">
             <BimServiceCard />
-            </div>
+          </div>
 
-            
-
-            
-        </div>
-        </section>
-
-      {/* PRODUCTOS */}
-      <section id="productos" className="py-16">
-        <div className="wrap-wide px-4">
-          <h2 className="text-2xl md:text-3xl font-bold">Nuestros productos</h2>
-          <p className="mt-2 text-gray-700">Plantillas, Excel y plataforma para acelerar tu trabajo diario.</p>
-
-          <div className="mt-8 grid gap-6 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-            {products.map((p) => (
-              <article key={p.slug} className="p-6 border rounded-2xl bg-white">
-                <h3 className="text-lg font-semibold">{p.title}</h3>
-                {p.desc && <p className="mt-2 text-gray-700">{p.desc}</p>}
-                <div className="mt-4 font-bold">{p.price}</div>
-                <div className="mt-4 flex gap-3">
-                  <a href={`/producto/${p.slug}`} className="btn-primary">Ver más</a>
-                  <a href="/contacto" className="btn-outline">Consultar</a>
-                </div>
-              </article>
-            ))}
+          <div className="mt-10 text-center">
+            <a href="/servicios" className="btn-outline">
+              Ver todos los servicios
+            </a>
           </div>
         </div>
       </section>
@@ -89,10 +71,16 @@ export default function Home() {
       <section className="bg-primary">
         <div className="wrap-wide px-4 py-14 text-center text-white">
           <h2 className="text-2xl md:text-3xl font-bold">¿Arrancamos?</h2>
-          <p className="mt-3 opacity-90">Accede a manuales, blog y a nuestra plataforma para presupuesto con APU.</p>
+          <p className="mt-3 opacity-90">
+            Accede a manuales, blog y a nuestra plataforma para presupuesto con APU.
+          </p>
           <div className="mt-6 flex gap-3 justify-center">
-            <a href="/manuales" className="btn bg-white text-primary hover:opacity-90 border-transparent">Ver manuales</a>
-            <a href="/blog" className="btn-outline border-white text-white hover:bg-white/10">Blog</a>
+            <a href="/manuales" className="btn bg-white text-primary hover:opacity-90 border-transparent">
+              Ver manuales
+            </a>
+            <a href="/blog" className="btn-outline border-white text-white hover:bg-white/10">
+              Blog
+            </a>
           </div>
         </div>
       </section>

--- a/src/pages/Manuales.jsx
+++ b/src/pages/Manuales.jsx
@@ -1,0 +1,18 @@
+import React from "react"
+
+export default function Manuales() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Manual de Uso</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Encuentra procedimientos paso a paso para aprovechar todas las herramientas de Civiles
+          Pro.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Estamos organizando los manuales y guías descargables. Vuelve pronto.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Planes.jsx
+++ b/src/pages/Planes.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default function Planes() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Planes</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Elige la suscripción que mejor se adapte al tamaño y necesidades de tu equipo.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Estamos construyendo la comparativa de planes. Déjanos tus datos para avisarte.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Plataforma.jsx
+++ b/src/pages/Plataforma.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+
+export default function Plataforma() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Plataforma</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Gestiona presupuestos, materiales y reportes diarios desde un solo lugar.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Muy pronto podrás conocer a fondo las funcionalidades de nuestra plataforma.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Productos.jsx
+++ b/src/pages/Productos.jsx
@@ -1,0 +1,18 @@
+import React from "react"
+
+export default function Productos() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Productos Civiles Pro</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Descubre el catálogo de plantillas, recursos y soluciones digitales que impulsan tus
+          proyectos.
+        </p>
+        <div className="mt-12 rounded-3xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center text-gray-600">
+          Próximamente encontrarás más información sobre nuestros productos destacados.
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Servicios.jsx
+++ b/src/pages/Servicios.jsx
@@ -1,0 +1,33 @@
+import React from "react"
+import products from "../data/products.js"
+
+export default function Servicios() {
+  return (
+    <section className="py-16">
+      <div className="wrap-wide px-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary">Servicios Civiles Pro</h1>
+        <p className="mt-4 max-w-2xl text-lg text-gray-700">
+          Plantillas, herramientas y acompañamiento para que tus proyectos avancen con
+          confianza.
+        </p>
+
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+          {products.map((p) => (
+            <article key={p.slug} className="p-6 border rounded-2xl bg-white shadow-sm">
+              <h3 className="text-lg font-semibold">{p.title}</h3>
+              {p.desc && <p className="mt-2 text-gray-700">{p.desc}</p>}
+              <div className="mt-6 flex gap-3">
+                <a href={`/producto/${p.slug}`} className="btn-primary">
+                  Ver más
+                </a>
+                <a href="/contacto" className="btn-outline">
+                  Consultar
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- redesign the sticky header with centered navigation and brand-styled action buttons
- register routes for productos, cursos, certificados, plataforma, blog, manuales, servicios, planes y entrar, each sharing the global layout
- move the productos grid into the new servicios page and remove it from the home hero flow

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/pagina-principal/node_modules/@eslint/js/index.js')*
- `npm run build` *(fails: sh: 1: vite: not found)*
- `npx vite build` *(fails: 403 Forbidden fetching vite from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9473bf10832c8e6be044624777f4