### PR TITLE
Add announcement bar and expand servicios block

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,13 +2,15 @@ import React from "react"
 import { Outlet } from "react-router-dom"
 import Header from "./components/Header"
 import Footer from "./components/Footer"
+import AnnouncementBar from "./components/AnnouncementBar"
 
 export default function App() {
   return (
     <div className="min-h-screen flex flex-col">
+      <AnnouncementBar />
       <Header />
-      {/* Header fijo (h-20): compensamos con pt-20 */}
-      <main className="flex-1 pt-20 md:pt-24">
+      {/* Header fijo + announcement bar: compensamos con padding superior */}
+      <main className="flex-1 pt-[120px] md:pt-[136px]">
         {/* ⛔️ sin wrapper global para permitir secciones full-bleed */}
         <Outlet />
       </main>

--- a/src/components/AnnouncementBar.jsx
+++ b/src/components/AnnouncementBar.jsx
@@ -1,0 +1,21 @@
+import React from "react"
+
+const MESSAGE =
+  "Ingenieros, arquitectos y maestros de obra compartiendo recursos, plantillas y herramientas para que tu obra sea más rápida y confiable."
+
+export default function AnnouncementBar() {
+  return (
+    <div className="fixed inset-x-0 top-0 z-[60] bg-emerald-900 text-white">
+      <div className="group relative h-9 md:h-10 overflow-hidden">
+        <div className="announcement-track flex w-max items-center gap-12 whitespace-nowrap px-6 text-sm md:text-base group-hover:[animation-play-state:paused]">
+          {[0, 1].map((index) => (
+            <p key={index} className="flex items-center gap-3">
+              <span className="font-semibold">Todo lo que un proyecto necesita, en un solo lugar.</span>
+              <span>{MESSAGE}</span>
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ExpandableCard.jsx
+++ b/src/components/ExpandableCard.jsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useMemo, useRef, useState } from "react"
+
+const getBadgeLabel = (item) => {
+  const match = item.match(/LOD\s*(\d+)/i)
+  return match ? match[1] : "+"
+}
+
+export default function ExpandableCard({ title, intro, items }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [maxHeight, setMaxHeight] = useState("0px")
+  const contentRef = useRef(null)
+
+  useEffect(() => {
+    if (isOpen && contentRef.current) {
+      setMaxHeight(`${contentRef.current.scrollHeight}px`)
+    } else {
+      setMaxHeight("0px")
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen || !contentRef.current || typeof ResizeObserver === "undefined") return
+
+    const observer = new ResizeObserver(() => {
+      if (contentRef.current) {
+        setMaxHeight(`${contentRef.current.scrollHeight}px`)
+      }
+    })
+
+    observer.observe(contentRef.current)
+    return () => observer.disconnect()
+  }, [isOpen])
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev)
+  }
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      handleToggle()
+    }
+  }
+
+  const handleButtonClick = (event) => {
+    event.stopPropagation()
+    handleToggle()
+  }
+
+  const stateClasses = useMemo(
+    () => ({
+      container: isOpen ? "-translate-y-2 shadow-lg" : "hover:-translate-y-1 hover:shadow-lg",
+      content: isOpen ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
+    }),
+    [isOpen],
+  )
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      aria-expanded={isOpen}
+      onClick={handleToggle}
+      onKeyDown={handleKeyDown}
+      className={`h-full cursor-pointer rounded-2xl bg-white p-6 shadow-sm transition-transform duration-300 ease-out ${stateClasses.container}`}
+    >
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-xl font-semibold text-gray-900">{title}</h3>
+          <p className="mt-2 text-gray-600">{intro}</p>
+        </div>
+
+        <div
+          style={{ maxHeight }}
+          className="overflow-hidden transition-[max-height] duration-300 ease-out"
+        >
+          <div
+            ref={contentRef}
+            className={`space-y-3 pt-2 text-gray-700 transition-all duration-300 ease-out ${stateClasses.content}`}
+          >
+            <ul className="space-y-3">
+              {items.map((item) => (
+                <li key={item} className="flex items-start gap-3">
+                  <span className="mt-0.5 inline-flex h-6 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-xs font-semibold text-emerald-700">
+                    LOD {getBadgeLabel(item)}
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="pt-2">
+          <button
+            type="button"
+            onClick={handleButtonClick}
+            className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-700"
+          >
+            <span>{isOpen ? "Ver menos" : "Ver más"}</span>
+            <svg
+              aria-hidden="true"
+              className={`h-4 w-4 transition-transform duration-300 ${isOpen ? "rotate-180" : ""}`}
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/components/FormatsGrid.jsx
+++ b/src/components/FormatsGrid.jsx
@@ -1,0 +1,34 @@
+import React from "react"
+
+const cards = [
+  {
+    title: "PDF / DWG / IFC",
+    description: "Archivos listos para coordinación y uso en plataformas como Navisworks, ArchiCAD, Tekla.",
+    accent: "from-emerald-500 to-emerald-300",
+  },
+  {
+    title: "RVT (opcional)",
+    description:
+      "Entregable bajo condiciones especiales, ya que contiene información diferenciadora del modelador.",
+    accent: "from-slate-500 to-slate-300",
+  },
+]
+
+export default function FormatsGrid() {
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      {cards.map((card) => (
+        <article
+          key={card.title}
+          className="rounded-2xl bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+        >
+          <div className={`h-36 w-full rounded-t-2xl bg-gradient-to-br ${card.accent} opacity-80`} aria-hidden />
+          <div className="space-y-3 p-6">
+            <h3 className="text-lg font-semibold text-gray-900">{card.title}</h3>
+            <p className="text-gray-700">{card.description}</p>
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -16,7 +16,7 @@ const baseLinkClasses =
 
 export default function Header() {
   return (
-    <header className="fixed inset-x-0 top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur">
+    <header className="fixed inset-x-0 top-[36px] md:top-[40px] z-50 border-b border-gray-200 bg-white/95 backdrop-blur">
       <div className="wrap-wide px-4">
         <div className="flex h-20 items-center gap-6">
           <a href="/" aria-label="Inicio" className="shrink-0">

--- a/src/components/ServiceCard.jsx
+++ b/src/components/ServiceCard.jsx
@@ -1,0 +1,44 @@
+import React from "react"
+
+function DefaultBulletIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-5 w-5 text-emerald-600"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M5 13l4 4L19 7" />
+    </svg>
+  )
+}
+
+export default function ServiceCard({ title, description, items = [], bulletIcon: BulletIcon = DefaultBulletIcon }) {
+  return (
+    <article className="h-full rounded-2xl bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-xl font-semibold text-gray-900">{title}</h3>
+          {description && <p className="mt-2 text-gray-600">{description}</p>}
+        </div>
+
+        {items.length > 0 && (
+          <ul className="space-y-3 text-gray-700">
+            {items.map((item) => (
+              <li key={item} className="flex items-start gap-3">
+                <span className="mt-0.5">
+                  <BulletIcon />
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,17 @@ body { margin: 0; background: #fff; color: #111; }
 .wrap       { @apply mx-auto w-full max-w-7xl; }            /* ~1280px */
 .wrap-wide  { @apply mx-auto w-full max-w-screen-2xl; }     /* ~1536px */
 .wrap-fluid { @apply w-full; }                               /* 100% */
+
+/* Announcement bar marquee */
+@keyframes announcement-marquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+.announcement-track {
+  animation: announcement-marquee 25s linear infinite;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,9 @@
 import React from "react"
 import SEO from "../components/SEO.jsx"
 import BimServiceCard from "../components/BimServiceCard.jsx"
+import ServiceCard from "../components/ServiceCard.jsx"
+import ExpandableCard from "../components/ExpandableCard.jsx"
+import FormatsGrid from "../components/FormatsGrid.jsx"
 
 export default function Home() {
   const jsonLd = {
@@ -18,6 +21,31 @@ export default function Home() {
     "description":
       "Comunidad de ingenieros, arquitectos y maestros de obra. Calcula materiales, genera presupuestos con APU y exporta a Excel.",
   }
+
+  const pebItems = [
+    "Definición de roles y responsabilidades.",
+    "Procesos de trabajo colaborativos.",
+    "Estándares y normas internacionales.",
+    "Entregables BIM claros y estructurados.",
+  ]
+
+  const lodItems = [
+    "LOD 100: Idea / Anteproyecto conceptual.",
+    "LOD 200: Diseño preliminar.",
+    "LOD 300: Geometría precisa y coordinación.",
+    "LOD 400: Construcción y documentación.",
+    "LOD 500: Proyecto final para operación y mantenimiento.",
+  ]
+
+  const projectItems = [
+    "Nave Industrial (Arquitectura + Estructuras).",
+    "Vivienda Unifamiliar (Arquitectura).",
+    "Edificio Residencial (Arquitectura + MEP).",
+    "Hospital de Primer Nivel (Arquitectura + Estructuras + MEP).",
+    "Bloque Escolar (Arquitectura + Estructuras).",
+    "Centros de Atención IPS (Arquitectura).",
+    "Edificio Multifuncional (Estructuras).",
+  ]
 
   return (
     <>
@@ -56,13 +84,26 @@ export default function Home() {
 
           {/* Tarjeta hero de Modelado BIM */}
           <div className="mt-8">
-            <BimServiceCard />
+            <BimServiceCard
+              title={"Modelado BIM\nbajo protocolos ISO 19650"}
+              subtitle="Integramos todas las disciplinas en un solo proyecto, asegurando eficiencia y coordinación desde la etapa conceptual hasta la construcción."
+            />
           </div>
 
-          <div className="mt-10 text-center">
-            <a href="/servicios" className="btn-outline">
-              Ver todos los servicios
-            </a>
+          <div className="mt-10 grid gap-6 lg:grid-cols-2">
+            <ServiceCard title="Planes de Ejecución BIM (PEB)" items={pebItems} />
+
+            <ExpandableCard
+              title="LOD – Niveles de Desarrollo"
+              intro="Adaptamos el nivel de detalle según la etapa del proyecto."
+              items={lodItems}
+            />
+
+            <ServiceCard title="Proyectos Ejecutados" items={projectItems} />
+
+            <div className="lg:col-span-2">
+              <FormatsGrid />
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add an animated announcement bar with marquee messaging above the fixed header
- build reusable cards for servicios, including expandable LOD details and a formats grid
- refresh the Home servicios section layout and adjust styles to accommodate the new components

## Testing
- npm run lint *(fails: missing @eslint/js package; registry returns 403 so lint cannot execute in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdae7650d0832cb55be6f9ea9d3e5a