### PR TITLE
Add diagnostic logging for PayPal integration

### DIFF
--- a/app/paypal_client.py
+++ b/app/paypal_client.py
@@ -2,16 +2,26 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Dict
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 PAYPAL_CLIENT_ID = os.environ.get("PAYPAL_CLIENT_ID")
 PAYPAL_CLIENT_SECRET = os.environ.get("PAYPAL_CLIENT_SECRET")
 PAYPAL_ENV = os.environ.get("PAYPAL_ENV", "sandbox").lower()
 
 PAYPAL_BASE_URL = "https://api-m.paypal.com" if PAYPAL_ENV == "live" else "https://api-m.sandbox.paypal.com"
+
+logger.info(
+    "PayPal client configured for '%s' environment. Client ID set: %s, client secret set: %s",
+    PAYPAL_ENV,
+    "yes" if PAYPAL_CLIENT_ID else "no",
+    "yes" if PAYPAL_CLIENT_SECRET else "no",
+)
 
 
 class PayPalError(RuntimeError):
@@ -22,21 +32,31 @@ async def _get_access_token() -> str:
     if not PAYPAL_CLIENT_ID or not PAYPAL_CLIENT_SECRET:
         raise PayPalError("Las credenciales de PayPal no están configuradas.")
 
-    async with httpx.AsyncClient(base_url=PAYPAL_BASE_URL, timeout=20.0) as client:
-        response = await client.post(
-            "/v1/oauth2/token",
-            data={"grant_type": "client_credentials"},
-            auth=(PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET),
-            headers={"Accept": "application/json", "Accept-Language": "es-ES"},
-        )
+    try:
+        async with httpx.AsyncClient(base_url=PAYPAL_BASE_URL, timeout=20.0) as client:
+            response = await client.post(
+                "/v1/oauth2/token",
+                data={"grant_type": "client_credentials"},
+                auth=(PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET),
+                headers={"Accept": "application/json", "Accept-Language": "es-ES"},
+            )
+    except httpx.RequestError as exc:  # pragma: no cover - network failure safeguard
+        logger.error("PayPal token request failed: %s", exc)
+        raise PayPalError("No se pudo conectar con PayPal para obtener el token de acceso.") from exc
 
     if response.status_code >= 400:
         detail = response.text
+        logger.error(
+            "PayPal token request returned %s: %s",
+            response.status_code,
+            detail,
+        )
         raise PayPalError(f"No se pudo obtener el token de acceso de PayPal: {detail}")
 
     data = response.json()
     token = data.get("access_token")
     if not token:
+        logger.error("PayPal token response without access_token field: %s", data)
         raise PayPalError("Respuesta inválida de PayPal al solicitar el token de acceso.")
 
     return token
@@ -67,10 +87,19 @@ async def create_order(amount_value: str, currency_code: str, description: str, 
         "Accept": "application/json",
     }
 
-    async with httpx.AsyncClient(base_url=PAYPAL_BASE_URL, timeout=20.0) as client:
-        response = await client.post("/v2/checkout/orders", json=payload, headers=headers)
+    try:
+        async with httpx.AsyncClient(base_url=PAYPAL_BASE_URL, timeout=20.0) as client:
+            response = await client.post("/v2/checkout/orders", json=payload, headers=headers)
+    except httpx.RequestError as exc:  # pragma: no cover - network failure safeguard
+        logger.error("PayPal create order request failed: %s", exc)
+        raise PayPalError("No se pudo conectar con PayPal para crear la orden.") from exc
 
     if response.status_code >= 400:
+        logger.error(
+            "PayPal create order request returned %s: %s",
+            response.status_code,
+            response.text,
+        )
         raise PayPalError(f"Error al crear la orden en PayPal: {response.text}")
 
     return response.json()
@@ -87,10 +116,20 @@ async def capture_order(order_id: str) -> Dict[str, Any]:
         "Accept": "application/json",
     }
 
-    async with httpx.AsyncClient(base_url=PAYPAL_BASE_URL, timeout=20.0) as client:
-        response = await client.post(f"/v2/checkout/orders/{order_id}/capture", headers=headers)
+    try:
+        async with httpx.AsyncClient(base_url=PAYPAL_BASE_URL, timeout=20.0) as client:
+            response = await client.post(f"/v2/checkout/orders/{order_id}/capture", headers=headers)
+    except httpx.RequestError as exc:  # pragma: no cover - network failure safeguard
+        logger.error("PayPal capture order request failed for %s: %s", order_id, exc)
+        raise PayPalError("No se pudo conectar con PayPal para capturar la orden.") from exc
 
     if response.status_code >= 400:
+        logger.error(
+            "PayPal capture order request returned %s for %s: %s",
+            response.status_code,
+            order_id,
+            response.text,
+        )
         raise PayPalError(f"Error al capturar la orden {order_id}: {response.text}")
 
     return response.json()

--- a/app/routes/paypal.py
+++ b/app/routes/paypal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -19,6 +20,8 @@ from ..models import DownloadToken, Purchase
 from ..paypal_client import PayPalError, capture_order as paypal_capture_order, create_order as paypal_create_order
 
 router = APIRouter(prefix="/api/paypal", tags=["paypal"])
+
+logger = logging.getLogger(__name__)
 
 DOWNLOAD_TOKEN_TTL_HOURS = int(os.environ.get("DOWNLOAD_TOKEN_TTL_HOURS", "24"))
 BACKEND_BASE_URL = os.environ.get("BACKEND_BASE_URL")
@@ -52,25 +55,41 @@ def _build_download_url(token_id: str) -> str:
 
 
 def _json_error(status_code: int, message: str) -> JSONResponse:
+    logger.warning("Responding with error %s: %s", status_code, message)
     return JSONResponse(status_code=status_code, content={"message": message})
 
 
 @router.post("/create-order", response_model=CreateOrderResponse)
 async def create_order_endpoint(payload: CreateOrderRequest, db: Session = Depends(get_session)) -> CreateOrderResponse | JSONResponse:
     currency = payload.currency.upper()
+    logger.info("Create order requested for slug='%s' with currency='%s'", payload.slug, currency)
     try:
         currency = catalog.normalize_currency(currency)
     except ValueError as exc:  # pragma: no cover - validation
+        logger.warning("Invalid currency provided for slug='%s': %s", payload.slug, exc)
         return _json_error(400, str(exc))
 
     product = catalog.get_product(payload.slug)
     if not product:
+        logger.warning("Product not found for slug='%s'", payload.slug)
         return _json_error(404, "Producto no encontrado")
 
     if product.price_cop is None or not product.file_key:
+        logger.warning(
+            "Product '%s' is not available for online purchase (price_cop=%s, file_key=%s)",
+            payload.slug,
+            product.price_cop,
+            bool(product.file_key),
+        )
         return _json_error(400, "Este producto no está disponible para compra en línea.")
 
     amount_decimal = catalog.convert_from_cop(product.price_cop, currency)
+    logger.info(
+        "Creating PayPal order for slug='%s' amount=%s %s",
+        payload.slug,
+        _amount_to_string(amount_decimal),
+        currency,
+    )
     try:
         paypal_response = await paypal_create_order(
             amount_value=_amount_to_string(amount_decimal),
@@ -79,12 +98,15 @@ async def create_order_endpoint(payload: CreateOrderRequest, db: Session = Depen
             reference_id=product.slug,
         )
     except PayPalError as exc:
+        logger.error("PayPal error while creating order for slug='%s': %s", payload.slug, exc)
         return _json_error(502, f"PayPal error: {exc}")
     except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Unexpected error while creating order for slug='%s'", payload.slug)
         return _json_error(500, f"Server error: {exc}")
 
     order_id = paypal_response.get("id")
     if not order_id:
+        logger.error("PayPal response without order id for slug='%s': %s", payload.slug, paypal_response)
         return _json_error(502, "Respuesta inválida de PayPal")
 
     purchase = Purchase(
@@ -100,18 +122,22 @@ async def create_order_endpoint(payload: CreateOrderRequest, db: Session = Depen
         db.add(purchase)
         db.commit()
     except Exception:  # pragma: no cover - commit protection
+        logger.exception("Database error while storing order '%s'", order_id)
         db.rollback()
         return _json_error(500, "No se pudo registrar la orden.")
 
+    logger.info("PayPal order created successfully for slug='%s' with order id '%s'", payload.slug, order_id)
     return CreateOrderResponse(orderID=order_id)
 
 
 @router.post("/capture-order", response_model=CaptureOrderResponse)
 async def capture_order_endpoint(payload: CaptureOrderRequest, db: Session = Depends(get_session)) -> CaptureOrderResponse | JSONResponse:
     order_id = payload.orderID
+    logger.info("Capture order requested for order id '%s'", order_id)
     purchase: Optional[Purchase] = db.query(Purchase).filter(Purchase.order_id == order_id).one_or_none()
 
     if not purchase:
+        logger.warning("Capture attempted for unknown order id '%s'", order_id)
         return _json_error(404, "Orden no registrada")
 
     now = datetime.now(timezone.utc)
@@ -124,30 +150,45 @@ async def capture_order_endpoint(payload: CaptureOrderRequest, db: Session = Dep
             .first()
         )
         if existing_token and existing_token.expires_at > now:
+            logger.info(
+                "Existing download token reused for order '%s' (token id '%s')",
+                order_id,
+                existing_token.id,
+            )
             return CaptureOrderResponse(downloadUrl=_build_download_url(existing_token.id))
 
     try:
         capture_data = await paypal_capture_order(order_id)
     except PayPalError as exc:
+        logger.error("PayPal error while capturing order '%s': %s", order_id, exc)
         return _json_error(502, f"PayPal error: {exc}")
     except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Unexpected error while capturing order '%s'", order_id)
         return _json_error(500, f"Server error: {exc}")
 
     if capture_data.get("status") != "COMPLETED":
+        logger.warning("Capture response for order '%s' not completed: %s", order_id, capture_data.get("status"))
         return _json_error(400, "La orden no fue completada.")
 
     purchase_units = capture_data.get("purchase_units") or []
     if not purchase_units:
+        logger.error("PayPal capture response missing purchase units for order '%s': %s", order_id, capture_data)
         return _json_error(400, "Orden de PayPal inválida")
 
     first_unit = purchase_units[0]
     payments = first_unit.get("payments", {})
     captures = payments.get("captures") or []
     if not captures:
+        logger.error("PayPal capture response missing captures for order '%s': %s", order_id, capture_data)
         return _json_error(400, "La orden no tiene capturas registradas")
 
     capture_entry = captures[0]
     if capture_entry.get("status") != "COMPLETED":
+        logger.warning(
+            "Capture entry for order '%s' is not completed: %s",
+            order_id,
+            capture_entry.get("status"),
+        )
         return _json_error(400, "La captura no fue completada")
 
     capture_amount = capture_entry.get("amount", {})
@@ -155,18 +196,32 @@ async def capture_order_endpoint(payload: CaptureOrderRequest, db: Session = Dep
     captured_currency = capture_amount.get("currency_code")
 
     if not captured_value or not captured_currency:
+        logger.error("Capture amount invalid for order '%s': %s", order_id, capture_entry)
         return _json_error(400, "Monto de captura inválido")
 
     try:
         captured_decimal = Decimal(captured_value)
     except Exception:  # pragma: no cover - defensive
+        logger.exception("Invalid capture amount format for order '%s': %s", order_id, capture_entry)
         return _json_error(400, "Monto de captura inválido")
 
     if captured_currency.upper() != purchase.currency.upper():
+        logger.error(
+            "Capture currency mismatch for order '%s': expected %s got %s",
+            order_id,
+            purchase.currency,
+            captured_currency,
+        )
         return _json_error(400, "Moneda de captura inválida")
 
     stored_amount = Decimal(purchase.amount)
     if captured_decimal != stored_amount:
+        logger.error(
+            "Capture amount mismatch for order '%s': expected %s got %s",
+            order_id,
+            stored_amount,
+            captured_decimal,
+        )
         return _json_error(400, "El monto capturado no coincide")
 
     payer_email = (capture_data.get("payer") or {}).get("email_address")
@@ -178,11 +233,13 @@ async def capture_order_endpoint(payload: CaptureOrderRequest, db: Session = Dep
     product = catalog.get_product(purchase.slug)
     if not product or not product.file_key:
         db.rollback()
+        logger.error("Product '%s' is missing file key during capture for order '%s'", purchase.slug, order_id)
         return _json_error(500, "Producto sin archivo configurado")
 
     expires_at = now + timedelta(hours=DOWNLOAD_TOKEN_TTL_HOURS)
+    token_id = str(uuid4())
     token = DownloadToken(
-        id=str(uuid4()),
+        id=token_id,
         slug=purchase.slug,
         file_key=product.file_key,
         order_id=order_id,
@@ -195,6 +252,13 @@ async def capture_order_endpoint(payload: CaptureOrderRequest, db: Session = Dep
         db.commit()
     except Exception:  # pragma: no cover - commit protection
         db.rollback()
+        logger.exception("Database error while finalizing order '%s'", order_id)
         return _json_error(500, "No se pudo finalizar la orden.")
 
+    logger.info(
+        "Order '%s' captured successfully. Download token '%s' generated with expiration %s",
+        order_id,
+        token_id,
+        expires_at.isoformat(),
+    )
     return CaptureOrderResponse(downloadUrl=_build_download_url(token.id))


### PR DESCRIPTION
## Summary
- add contextual logging to the PayPal client to highlight environment setup and API response issues
- log key decision points in the PayPal routes to surface catalog validation failures and PayPal error details

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d725a2fac4832c9677a9b9e0f90e33