### PR TITLE
Adjust PayPal order currency handling

### DIFF
--- a/app/catalog.py
+++ b/app/catalog.py
@@ -80,6 +80,22 @@ def convert_from_cop(amount_cop: int, currency: str) -> Decimal:
     return amount.quantize(quant, rounding=ROUND_HALF_UP)
 
 
+def convert_to_usd(amount: Decimal, from_currency: str) -> Decimal:
+    """Convert an amount from the selected currency to USD using local rates."""
+
+    currency_code = normalize_currency(from_currency)
+    if currency_code == "USD":
+        return amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    rate_from = EXCHANGE_RATES[currency_code]
+    if rate_from == 0:  # pragma: no cover - defensive safeguard
+        raise ValueError(f"Tasa de conversión inválida para {currency_code}")
+
+    amount_cop = amount / rate_from
+    amount_usd = amount_cop * EXCHANGE_RATES["USD"]
+    return amount_usd.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
 def normalize_currency(currency: str) -> str:
     """Normalize and validate the currency code."""
     upper = currency.upper()


### PR DESCRIPTION
## Summary
- add a helper to convert catalog prices to USD for PayPal fallbacks
- update the PayPal create order endpoint to normalize currencies and log USD fallbacks
- sanitize PayPal error messages to avoid returning HTML in JSON responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d72a03e064832ca6b0e03de2f14aca