### PR TITLE
Fix currency selector synchronization on Productos page

### DIFF
--- a/src/components/CurrencySelector.jsx
+++ b/src/components/CurrencySelector.jsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { SUPPORTED_CURRENCIES } from "../data/exchangeRates.js";
+
+export default function CurrencySelector({ value, onChange }) {
+  return (
+    <div className="flex flex-col gap-2 md:items-end">
+      <span className="text-sm font-medium text-gray-600">Moneda</span>
+      <div className="inline-flex max-w-full gap-1 overflow-x-auto rounded-full border border-gray-200 bg-white p-1 shadow-sm snap-x">
+        {SUPPORTED_CURRENCIES.map((code) => {
+          const active = code === value;
+          return (
+            <button
+              key={code}
+              type="button"
+              onClick={() => onChange(code)}
+              className={`snap-center rounded-full px-4 py-2 text-sm font-semibold transition-colors duration-200 whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
+                active ? "bg-emerald-600 text-white shadow" : "text-gray-700 hover:bg-emerald-50"
+              }`}
+            >
+              {code}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable CurrencySelector component for rendering the chip-style currency buttons
- centralize ProductosPage currency state initialization and effects to keep URL, localStorage, and UI in sync without loops
- wire the product grid to the new selector while preserving existing pricing display and modal behavior

## Testing
- npm run build *(fails: vite command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d74e7379dc832cad381e55851acdd7