### PR TITLE
Add social media icons to footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -9,6 +9,56 @@ export default function Footer() {
           <p className="mt-2 text-sm text-gray-600">
             Plantillas, herramientas y recursos para ingeniería y arquitectura.
           </p>
+          <div className="mt-4 flex items-center gap-3">
+            <a
+              href="https://www.facebook.com/ingcivilespro"
+              target="_blank"
+              rel="noreferrer"
+              className="text-gray-400 transition hover:text-emerald-600"
+            >
+              <span className="sr-only">Facebook</span>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-5 w-5"
+              >
+                <path d="M22 12a10 10 0 1 0-11.5 9.9v-7h-2v-2.9h2V9.7c0-2 1.2-3.1 3-3.1.9 0 1.8.1 1.8.1v2h-1c-1 0-1.3.6-1.3 1.2v1.9h2.2l-.4 2.9h-1.8v7A10 10 0 0 0 22 12" />
+              </svg>
+            </a>
+            <a
+              href="https://www.instagram.com/civilespro/"
+              target="_blank"
+              rel="noreferrer"
+              className="text-gray-400 transition hover:text-emerald-600"
+            >
+              <span className="sr-only">Instagram</span>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-5 w-5"
+              >
+                <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3zm5 3.8A4.2 4.2 0 1 1 7.8 12 4.2 4.2 0 0 1 12 7.8m0 2A2.2 2.2 0 1 0 14.2 12 2.2 2.2 0 0 0 12 9.8m5.5-3.6a1.1 1.1 0 1 1-1.1 1.1 1.1 1.1 0 0 1 1.1-1.1" />
+              </svg>
+            </a>
+            <a
+              href="https://www.tiktok.com/@ingcivilespro"
+              target="_blank"
+              rel="noreferrer"
+              className="text-gray-400 transition hover:text-emerald-600"
+            >
+              <span className="sr-only">TikTok</span>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-5 w-5"
+              >
+                <path d="M18 5.1a5.3 5.3 0 0 1-2.6-1.5 5.2 5.2 0 0 1-1.5-2.6h-2.5v14a2.2 2.2 0 1 1-3.5-1.8V10H5.4v3.2a4.7 4.7 0 1 0 7.2 4V9.2a7.9 7.9 0 0 0 4.8 1.6V8.3a5.6 5.6 0 0 1-1.4-.4 5.7 5.7 0 0 1-2-1.3 5.6 5.6 0 0 0 3 1z" />
+              </svg>
+            </a>
+          </div>
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
- add social media links for Facebook, Instagram, and TikTok to the footer
- include inline SVG icons with accessible labels and hover styling

## Testing
- not run (environment does not allow installing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d762a406cc832c893f11569bb109cc