### PR TITLE
Refactor BIM sections with collapsible LOD and project carousels

### DIFF
--- a/src/components/BimDeepSections.jsx
+++ b/src/components/BimDeepSections.jsx
@@ -1,136 +1,50 @@
-import React, { useState } from "react"
+import CollapseItem from "./ui/CollapseItem"
+import MediaWithText from "./ui/MediaWithText"
+import LODSection from "./bim/LODSection"
+import ProjectsSection from "./bim/ProjectsSection"
+import { deepSectionsIntro, pebSection } from "../data/BimDeepSections"
 
-const PEB_DETAILS = [
-  "Definimos entregables, flujos de trabajo y canales de comunicación para que todas las disciplinas avancen alineadas.",
-  "Estructuramos la documentación en función de la ISO 19650 para asegurar trazabilidad y control de versiones.",
-  "Establecemos métricas de seguimiento para medir avances y tomar decisiones a tiempo.",
-]
-
-const LOD_DETAILS = [
-  "Adaptamos el nivel de detalle a la fase del proyecto para optimizar tiempos y esfuerzo.",
-  "Integramos geometría, datos y especificaciones para facilitar la coordinación interdisciplinar.",
-  "Validamos el modelo con revisiones colaborativas y control de colisiones.",
-]
-
-const PROJECTS_DETAILS = [
-  "Modelado de edificaciones industriales, comerciales y residenciales con equipos multidisciplinares.",
-  "Coordinación MEP y estructural en proyectos hospitalarios y educativos.",
-  "Implementaciones BIM para operación y mantenimiento posterior a la entrega.",
-]
-
-const BIM_DEEP_SECTIONS = [
-  {
-    id: "peb",
-    title: "Planes de Ejecución BIM (PEB)",
-    summary:
-      "Metodología y documentación para coordinar a todos los participantes desde la concepción hasta la entrega.",
-    image: "/bim/peb.jpg",
-    items: PEB_DETAILS,
-  },
-  {
-    id: "lod",
-    title: "LOD – Niveles de Desarrollo",
-    summary: "Escalamos la precisión del modelo según la etapa del proyecto y las decisiones que se necesitan tomar.",
-    image: "/bim/lod.jpg",
-    items: LOD_DETAILS,
-  },
-  {
-    id: "projects",
-    title: "Proyectos Ejecutados",
-    summary: "Experiencia comprobada implementando flujos BIM en proyectos reales de distintas escalas.",
-    image: "/bim/projects.jpg",
-    items: PROJECTS_DETAILS,
-  },
-]
-
-function ChevronIcon({ expanded }) {
+function PebSectionCard() {
   return (
-    <svg
-      aria-hidden="true"
-      className={`h-5 w-5 transition-transform duration-300 ${expanded ? "rotate-180" : "rotate-0"}`}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth="1.5"
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-    </svg>
+    <section className="rounded-2xl bg-white p-6 shadow-sm md:p-8">
+      <CollapseItem title={pebSection.title} subtitle={pebSection.summary} defaultOpen>
+        <MediaWithText
+          media={
+            <img
+              src={pebSection.image}
+              alt={pebSection.title}
+              loading="lazy"
+              className="h-full w-full rounded-xl object-cover"
+            />
+          }
+        >
+          <ul className="space-y-3 text-sm text-slate-700 md:text-base">
+            {pebSection.items.map((item, index) => (
+              <li key={index} className="flex items-start gap-2">
+                <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-slate-400"></span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </MediaWithText>
+      </CollapseItem>
+    </section>
   )
 }
 
 export default function BimDeepSections() {
-  const [openId, setOpenId] = useState(BIM_DEEP_SECTIONS[0]?.id ?? null)
-
-  const handleToggle = (id) => {
-    setOpenId((current) => (current === id ? null : id))
-  }
-
   return (
     <section className="bg-white py-16">
       <div className="mx-auto max-w-7xl px-4">
         <div className="mx-auto max-w-3xl text-center">
-          <h2 className="text-2xl md:text-3xl font-bold text-gray-900">Profundiza en nuestro enfoque BIM</h2>
-          <p className="mt-3 text-gray-600">
-            Explora cómo estructuramos procesos, niveles de detalle y la experiencia que respalda cada proyecto que modelamos.
-          </p>
+          <h2 className="text-2xl font-bold text-gray-900 md:text-3xl">{deepSectionsIntro.title}</h2>
+          <p className="mt-3 text-gray-600">{deepSectionsIntro.description}</p>
         </div>
 
-        <div className="mt-10 space-y-6">
-          {BIM_DEEP_SECTIONS.map((section) => {
-            const isOpen = openId === section.id
-            const contentId = `${section.id}-content`
-
-            return (
-              <article key={section.id} className="rounded-2xl border border-gray-200 bg-gray-50 shadow-sm">
-                <button
-                  type="button"
-                  id={`${section.id}-trigger`}
-                  className="flex w-full items-center justify-between gap-4 rounded-2xl px-6 py-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  aria-expanded={isOpen}
-                  aria-controls={contentId}
-                  onClick={() => handleToggle(section.id)}
-                >
-                  <div>
-                    <p className="text-lg font-semibold text-gray-900">{section.title}</p>
-                    <p className="mt-1 text-sm text-gray-600">{section.summary}</p>
-                  </div>
-                  <ChevronIcon expanded={isOpen} />
-                </button>
-
-                <div
-                  id={contentId}
-                  role="region"
-                  aria-labelledby={`${section.id}-trigger`}
-                  className={`grid transition-[grid-template-rows] duration-500 ease-in-out ${isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}
-                >
-                  <div className="overflow-hidden">
-                    <div className="border-t border-gray-200 px-6 py-6">
-                      <div className="flex flex-col gap-6 md:flex-row md:items-center">
-                        <div className="md:w-1/2">
-                          <ul className="space-y-3 text-sm text-gray-700">
-                            {section.items.map((item, index) => (
-                              <li key={index} className="flex items-start gap-2">
-                                <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-primary"></span>
-                                <span>{item}</span>
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                        <div className="md:w-1/2">
-                          <img
-                            src={section.image}
-                            alt={section.title}
-                            loading="lazy"
-                            className="h-full w-full rounded-xl object-cover"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </article>
-            )
-          })}
+        <div className="mt-10 space-y-6 md:space-y-8">
+          <PebSectionCard />
+          <LODSection />
+          <ProjectsSection />
         </div>
       </div>
     </section>

--- a/src/components/bim/LODSection.jsx
+++ b/src/components/bim/LODSection.jsx
@@ -1,0 +1,66 @@
+import CollapseItem from "../ui/CollapseItem"
+import ImageCarousel from "../ui/ImageCarousel"
+import MediaWithText from "../ui/MediaWithText"
+import { lodItems, lodSection } from "../../data/BimDeepSections"
+
+const WHATS_NUMBER = "57XXXXXXXXXX"
+
+function BrainIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M8.5 3.5A3.5 3.5 0 0 0 5 7v2.25c0 .414-.336.75-.75.75h-.5A1.75 1.75 0 0 0 2 11.75v.5c0 .966.784 1.75 1.75 1.75H5" />
+      <path d="M5 14v.75A3.25 3.25 0 0 0 8.25 18H9" />
+      <path d="M15.5 3.5A3.5 3.5 0 0 1 19 7v2.25c0 .414.336.75.75.75h.5A1.75 1.75 0 0 1 22 11.75v.5A1.75 1.75 0 0 1 20.25 14H19" />
+      <path d="M19 14v.75A3.25 3.25 0 0 1 15.75 18H15" />
+      <path d="M9 6.75A2.25 2.25 0 0 1 11.25 4.5H12a2.5 2.5 0 0 1 2.5 2.5V7" />
+      <path d="M9 10.5A2.5 2.5 0 0 0 11.5 13v.5A2.5 2.5 0 0 1 9 16" />
+      <path d="M15 6.75A2.25 2.25 0 0 0 12.75 4.5H12a2.5 2.5 0 0 0-2.5 2.5V7" />
+      <path d="M15 10.5A2.5 2.5 0 0 1 12.5 13v.5A2.5 2.5 0 0 0 15 16" />
+    </svg>
+  )
+}
+
+export default function LODSection() {
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm md:p-8">
+      <header>
+        <h3 className="text-xl font-semibold text-slate-900 md:text-2xl">{lodSection.title}</h3>
+        <p className="mt-2 text-sm text-slate-600 md:text-base">{lodSection.summary}</p>
+      </header>
+      <div className="mt-6 space-y-4 md:space-y-5">
+        {lodItems.map((item) => (
+          <CollapseItem
+            key={item.id}
+            title={item.title}
+            subtitle={item.short}
+            leadingIcon={<BrainIcon />}
+          >
+            <MediaWithText
+              media={<ImageCarousel images={item.images} className="mt-4 md:mt-0" />}
+            >
+              <div className="flex flex-col gap-4">
+                <p className="text-slate-600 text-sm leading-6 md:text-base">{item.desc}</p>
+                <a
+                  href={`https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(item.whatsMsg)}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-slate-500 underline underline-offset-4 transition-colors hover:text-slate-700"
+                >
+                  ¿Este nivel encaja con tu proyecto? Escríbenos por WhatsApp
+                </a>
+              </div>
+            </MediaWithText>
+          </CollapseItem>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/bim/ProjectsSection.jsx
+++ b/src/components/bim/ProjectsSection.jsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from "react"
+import CollapseItem from "../ui/CollapseItem"
+import MediaWithText from "../ui/MediaWithText"
+import { executedProjects, projectsSection } from "../../data/BimDeepSections"
+
+function ImageFrame({ src, alt }) {
+  return (
+    <div className="overflow-hidden rounded-xl bg-slate-100">
+      <div className="aspect-video w-full">
+        {src ? (
+          <img src={src} alt={alt} className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">Sin vista disponible</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function OptionPills({ options, active, onChange }) {
+  if (!options?.length) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        const isActive = option === active
+        return (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            className={`rounded-full border px-2 py-1 text-xs font-medium transition-colors ${
+              isActive
+                ? "border-slate-900 bg-slate-900 text-white"
+                : "border-slate-300 text-slate-600 hover:border-slate-400 hover:text-slate-800"
+            }`}
+          >
+            {option}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function ProjectItem({ project }) {
+  const [activeDiscipline, setActiveDiscipline] = useState(project.disciplines[0] ?? null)
+  const [activeLOD, setActiveLOD] = useState(project.lodLevels[0] ?? null)
+  const [activeComplexity, setActiveComplexity] = useState(project.complexity?.options?.[0] ?? null)
+
+  const resolvedImage = useMemo(() => {
+    const { images } = project
+    if (!images) return null
+
+    if (images.imagesByDisciplineAndLOD && activeDiscipline && activeLOD) {
+      const byDiscipline = images.imagesByDisciplineAndLOD[activeDiscipline]
+      const byLod = byDiscipline?.[activeLOD]
+      if (byLod) {
+        return byLod
+      }
+    }
+
+    if (images.imagesByDiscipline && activeDiscipline) {
+      const byDiscipline = images.imagesByDiscipline[activeDiscipline]
+      if (byDiscipline) {
+        return byDiscipline
+      }
+    }
+
+    if (images.imagesByLOD && activeLOD) {
+      const byLod = images.imagesByLOD[activeLOD]
+      if (byLod) {
+        return byLod
+      }
+    }
+
+    if (images.imagesByComplexity && activeComplexity) {
+      const byComplexity = images.imagesByComplexity[activeComplexity]
+      if (byComplexity) {
+        return byComplexity
+      }
+    }
+
+    return images.main ?? null
+  }, [project, activeDiscipline, activeLOD, activeComplexity])
+
+  return (
+    <CollapseItem title={project.name} subtitle={project.summary} defaultOpen={false}>
+      <MediaWithText media={<ImageFrame src={resolvedImage} alt={project.name} />}>
+        <div className="space-y-4">
+          <CollapseItem
+            title="Disciplina"
+            subtitle="Selecciona la disciplina que quieres analizar"
+            level="sub"
+            defaultOpen
+          >
+            <OptionPills options={project.disciplines} active={activeDiscipline} onChange={setActiveDiscipline} />
+          </CollapseItem>
+
+          <CollapseItem
+            title="Nivel de Detalle (LOD)"
+            subtitle="Explora cómo evoluciona el modelo"
+            level="sub"
+            defaultOpen
+          >
+            <OptionPills options={project.lodLevels} active={activeLOD} onChange={setActiveLOD} />
+          </CollapseItem>
+
+          <CollapseItem
+            title={project.complexity?.title ?? "Tipo de Edificio y Complejidad"}
+            subtitle="Contexto del proyecto"
+            level="sub"
+            defaultOpen
+          >
+            <div className="space-y-2 text-xs text-slate-600">
+              <p className="leading-5">{project.complexity?.text}</p>
+              <OptionPills
+                options={project.complexity?.options}
+                active={activeComplexity}
+                onChange={setActiveComplexity}
+              />
+            </div>
+          </CollapseItem>
+
+          <p className="text-xs text-slate-500">
+            Entrega final: {project.deliverables?.join(" / ") ?? "IFC / PDF / DWG"}
+          </p>
+        </div>
+      </MediaWithText>
+    </CollapseItem>
+  )
+}
+
+export default function ProjectsSection() {
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-sm md:p-8">
+      <header>
+        <h3 className="text-xl font-semibold text-slate-900 md:text-2xl">{projectsSection.title}</h3>
+        <p className="mt-2 text-sm text-slate-600 md:text-base">{projectsSection.summary}</p>
+      </header>
+      <div className="mt-6 space-y-4 md:space-y-5">
+        {executedProjects.map((project) => (
+          <ProjectItem key={project.id} project={project} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/ui/CollapseItem.jsx
+++ b/src/components/ui/CollapseItem.jsx
@@ -1,0 +1,103 @@
+import { useState, useMemo, useEffect, useRef } from "react"
+
+const levelStyles = {
+  main: {
+    container: "border border-slate-200 rounded-xl bg-slate-50",
+    trigger: "px-4 py-3 md:px-5 md:py-4",
+    title: "text-lg font-semibold text-slate-900",
+    subtitle: "text-sm text-slate-600",
+  },
+  sub: {
+    container: "border border-slate-200 rounded-lg bg-white",
+    trigger: "px-3 py-2",
+    title: "text-sm font-medium text-slate-900",
+    subtitle: "text-xs text-slate-500",
+  },
+}
+
+const chevronBase =
+  "ml-auto flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition-transform duration-300"
+
+export default function CollapseItem({
+  title,
+  subtitle,
+  defaultOpen = false,
+  children,
+  level = "main",
+  leadingIcon = null,
+  className = "",
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [maxHeight, setMaxHeight] = useState(defaultOpen ? "none" : "0px")
+  const contentRef = useRef(null)
+
+  const styles = useMemo(() => levelStyles[level] ?? levelStyles.main, [level])
+
+  useEffect(() => {
+    const node = contentRef.current
+    if (!node) return
+
+    const height = node.scrollHeight
+
+    if (isOpen) {
+      setMaxHeight(`${height}px`)
+      const timeout = setTimeout(() => {
+        setMaxHeight("none")
+      }, 300)
+      return () => clearTimeout(timeout)
+    }
+
+    setMaxHeight(`${height}px`)
+    requestAnimationFrame(() => {
+      setMaxHeight("0px")
+    })
+  }, [isOpen])
+
+  return (
+    <div className={`${styles.container} ${className}`.trim()}>
+      <button
+        type="button"
+        className={`flex w-full items-center gap-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 ${styles.trigger}`}
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+      >
+        {leadingIcon ? (
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-200/70 text-slate-700">
+            {leadingIcon}
+          </span>
+        ) : null}
+        <div className="flex-1">
+          <div className={`flex items-start gap-2 ${leadingIcon ? "mt-0.5" : ""}`}>
+            <span className={styles.title}>{title}</span>
+          </div>
+          {subtitle ? <p className={`${styles.subtitle} mt-1`}>{subtitle}</p> : null}
+        </div>
+        <span className={`${chevronBase} ${isOpen ? "rotate-180" : "rotate-0"}`} aria-hidden="true">
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </span>
+      </button>
+      <div
+        style={{
+          maxHeight: maxHeight === "none" ? undefined : maxHeight,
+          overflow: "hidden",
+          transition: "max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s",
+          opacity: isOpen || maxHeight !== "0px" ? 1 : 0,
+        }}
+      >
+        <div ref={contentRef} className={`px-4 pb-4 pt-0 md:px-5 ${level === "sub" ? "text-sm" : "text-base"}`}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/ImageCarousel.jsx
+++ b/src/components/ui/ImageCarousel.jsx
@@ -1,0 +1,77 @@
+import { useState, useMemo } from "react"
+
+export default function ImageCarousel({ images = [], className = "" }) {
+  const sanitizedImages = useMemo(() => images.filter(Boolean), [images])
+  const [current, setCurrent] = useState(0)
+
+  if (sanitizedImages.length === 0) {
+    return null
+  }
+
+  const goToIndex = (index) => {
+    const total = sanitizedImages.length
+    if (total === 0) return
+    const nextIndex = (index + total) % total
+    setCurrent(nextIndex)
+  }
+
+  const handlePrev = () => {
+    goToIndex(current - 1)
+  }
+
+  const handleNext = () => {
+    goToIndex(current + 1)
+  }
+
+  return (
+    <div className={`relative w-full overflow-hidden rounded-xl bg-slate-100 ${className}`.trim()}>
+      <div className="aspect-video w-full">
+        <img
+          src={sanitizedImages[current]}
+          alt="Visualización LOD"
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      </div>
+      {sanitizedImages.length > 1 ? (
+        <>
+          <div className="pointer-events-none absolute inset-y-0 left-0 right-0 flex items-center justify-between p-2">
+            <button
+              type="button"
+              onClick={handlePrev}
+              className="pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-slate-700 shadow"
+              aria-label="Imagen anterior"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="m15 6-6 6 6 6" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              className="pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-slate-700 shadow"
+              aria-label="Imagen siguiente"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="m9 6 6 6-6 6" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          </div>
+          <div className="pointer-events-none absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-1">
+            {sanitizedImages.map((_, index) => (
+              <button
+                key={index}
+                type="button"
+                onClick={() => goToIndex(index)}
+                className={`pointer-events-auto h-2.5 w-2.5 rounded-full transition-opacity ${
+                  current === index ? "bg-slate-900 opacity-90" : "bg-white opacity-60"
+                }`}
+                aria-label={`Mostrar imagen ${index + 1}`}
+              />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/ui/MediaWithText.jsx
+++ b/src/components/ui/MediaWithText.jsx
@@ -1,0 +1,15 @@
+export default function MediaWithText({ media, children, reverse = false, className = "" }) {
+  const textOrder = reverse ? "md:order-2" : "md:order-1"
+  const mediaOrder = reverse ? "md:order-1" : "md:order-2"
+
+  return (
+    <div className={`grid gap-6 md:grid-cols-12 md:gap-8 ${className}`.trim()}>
+      <div className={`md:col-span-7 ${textOrder}`}>
+        {children}
+      </div>
+      <div className={`md:col-span-5 ${mediaOrder}`}>
+        {media}
+      </div>
+    </div>
+  )
+}

--- a/src/data/BimDeepSections.jsx
+++ b/src/data/BimDeepSections.jsx
@@ -1,0 +1,309 @@
+export const deepSectionsIntro = {
+  title: "Profundiza en nuestro enfoque BIM",
+  description:
+    "Explora cómo estructuramos procesos, niveles de detalle y la experiencia que respalda cada proyecto que modelamos.",
+}
+
+export const pebSection = {
+  id: "peb",
+  title: "Planes de Ejecución BIM (PEB)",
+  summary:
+    "Metodología y documentación para coordinar a todos los participantes desde la concepción hasta la entrega.",
+  image: "/bim/peb.jpg",
+  items: [
+    "Definimos entregables, flujos de trabajo y canales de comunicación para que todas las disciplinas avancen alineadas.",
+    "Estructuramos la documentación en función de la ISO 19650 para asegurar trazabilidad y control de versiones.",
+    "Establecemos métricas de seguimiento para medir avances y tomar decisiones a tiempo.",
+  ],
+}
+
+export const lodSection = {
+  id: "lod",
+  title: "LOD – Niveles de Desarrollo",
+  summary:
+    "Escalamos la precisión del modelo según la etapa del proyecto y las decisiones que se necesitan tomar.",
+}
+
+export const projectsSection = {
+  id: "projects",
+  title: "Proyectos Ejecutados",
+  summary:
+    "Experiencia comprobada implementando flujos BIM en proyectos reales de distintas escalas.",
+}
+
+export const lodItems = [
+  {
+    id: "lod100",
+    icon: "brain",
+    title: "LOD 100: Idea / Anteproyecto conceptual",
+    short: "Modelo conceptual para evaluar volumen, áreas y alternativas; útil para estimaciones de alto nivel.",
+    desc: "Modelo a nivel conceptual que apoya decisiones tempranas: volumetrías, relaciones espaciales y supuestos de costos/plazos. Útil para evaluar alternativas y riesgos sin comprometer diseño detallado.",
+    images: [
+      "/img/bim/lod100/01.webp",
+      "/img/bim/lod100/02.webp",
+      "/img/bim/lod100/03.webp",
+    ],
+    whatsMsg:
+      "Hola, me interesa el servicio LOD 100 (Idea/Anteproyecto). ¿Podemos hablar de mi proyecto?",
+  },
+  {
+    id: "lod200",
+    icon: "brain",
+    title: "LOD 200: Desarrollo esquemático",
+    short: "Diseño preliminar con geometrías aproximadas y ubicación de sistemas; base para coordinación inicial.",
+    desc: "Modelo que incorpora geometrías aproximadas y ubicación general de sistemas. Permite validar criterios de diseño, estimar cantidades preliminares y preparar la coordinación interdisciplinar inicial.",
+    images: [
+      "/img/bim/lod200/01.webp",
+      "/img/bim/lod200/02.webp",
+      "/img/bim/lod200/03.webp",
+    ],
+    whatsMsg:
+      "Hola, me interesa el servicio LOD 200 (Desarrollo esquemático). ¿Podemos hablar de mi proyecto?",
+  },
+  {
+    id: "lod300",
+    icon: "brain",
+    title: "LOD 300: Diseño coordinado",
+    short: "Geometría definida y relaciones precisas; lista para coordinación técnica y extracción confiable de cantidades.",
+    desc: "Modelo con geometría definida, relaciones precisas y especificaciones asociadas. Facilita la coordinación técnica entre disciplinas y permite extraer cantidades confiables para planeación y compras.",
+    images: [
+      "/img/bim/lod300/01.webp",
+      "/img/bim/lod300/02.webp",
+      "/img/bim/lod300/03.webp",
+    ],
+    whatsMsg:
+      "Hola, me interesa el servicio LOD 300 (Diseño coordinado). ¿Podemos hablar de mi proyecto?",
+  },
+  {
+    id: "lod400",
+    icon: "brain",
+    title: "LOD 400: Construcción y prefabricación",
+    short: "Modelo para construcción y fabricación; incluye detalles y ensamblajes para producción en obra/taller.",
+    desc: "Modelo listo para construcción y prefabricación, con detalles constructivos, secuencias y ensamblajes. Soporta la fabricación en taller y la logística de montaje en obra.",
+    images: [
+      "/img/bim/lod400/01.webp",
+      "/img/bim/lod400/02.webp",
+      "/img/bim/lod400/03.webp",
+    ],
+    whatsMsg:
+      "Hola, me interesa el servicio LOD 400 (Construcción/prefabricación). ¿Podemos hablar de mi proyecto?",
+  },
+  {
+    id: "lod500",
+    icon: "brain",
+    title: "LOD 500: Operación y mantenimiento",
+    short: "Modelo conforme a obra (as-built) para operación y mantenimiento.",
+    desc: "Modelo conforme a obra que documenta el estado final del activo. Integra información para operación, mantenimiento preventivo y gestión del ciclo de vida de la infraestructura.",
+    images: [
+      "/img/bim/lod500/01.webp",
+      "/img/bim/lod500/02.webp",
+      "/img/bim/lod500/03.webp",
+    ],
+    whatsMsg:
+      "Hola, me interesa el servicio LOD 500 (Operación/Mantenimiento). ¿Podemos hablar de mi proyecto?",
+  },
+]
+
+export const executedProjects = [
+  {
+    id: "nave-industrial",
+    name: "Nave Industrial",
+    summary:
+      "Modelado integral para nave logística con coordinación de estructuras y arquitectura en etapas tempranas.",
+    disciplines: ["Arquitectura", "Estructuras"],
+    lodLevels: ["LOD 200", "LOD 300"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Nave industrial de uso múltiple para almacenamiento y operaciones logísticas ligeras. Pórticos en acero y elementos en concreto reforzado.",
+      options: ["Complejidad Media"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/nave/main.webp",
+      imagesByDiscipline: {
+        Arquitectura: "/img/proyectos/nave/arq.webp",
+        Estructuras: "/img/proyectos/nave/est.webp",
+      },
+      imagesByLOD: {
+        "LOD 200": "/img/proyectos/nave/lod200.webp",
+        "LOD 300": "/img/proyectos/nave/lod300.webp",
+      },
+    },
+  },
+  {
+    id: "vivienda-unifamiliar",
+    name: "Vivienda Unifamiliar",
+    summary:
+      "Residencia unifamiliar optimizada para un cronograma acelerado y control de costos desde la fase esquemática.",
+    disciplines: ["Arquitectura"],
+    lodLevels: ["LOD 200"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Vivienda unifamiliar de baja complejidad, optimizada para tiempos de obra y costos.",
+      options: ["Baja Complejidad"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/vivienda/main.webp",
+      imagesByDiscipline: { Arquitectura: "/img/proyectos/vivienda/arq.webp" },
+      imagesByLOD: { "LOD 200": "/img/proyectos/vivienda/lod200.webp" },
+    },
+  },
+  {
+    id: "edificio-residencial",
+    name: "Edificio Residencial",
+    summary:
+      "Torre de vivienda multifamiliar con coordinación entre arquitectura y sistemas MEP para mitigación de interferencias.",
+    disciplines: ["Arquitectura", "MEP"],
+    lodLevels: ["LOD 200", "LOD 300"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Edificio residencial de media altura con énfasis en eficiencia energética y confort interior.",
+      options: ["Complejidad Alta"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/residencial/main.webp",
+      imagesByDiscipline: {
+        Arquitectura: "/img/proyectos/residencial/arq.webp",
+        MEP: "/img/proyectos/residencial/mep.webp",
+      },
+      imagesByLOD: {
+        "LOD 200": "/img/proyectos/residencial/lod200.webp",
+        "LOD 300": "/img/proyectos/residencial/lod300.webp",
+      },
+      imagesByDisciplineAndLOD: {
+        Arquitectura: {
+          "LOD 200": "/img/proyectos/residencial/arq-lod200.webp",
+          "LOD 300": "/img/proyectos/residencial/arq-lod300.webp",
+        },
+        MEP: {
+          "LOD 200": "/img/proyectos/residencial/mep-lod200.webp",
+          "LOD 300": "/img/proyectos/residencial/mep-lod300.webp",
+        },
+      },
+    },
+  },
+  {
+    id: "hospital-primer-nivel",
+    name: "Hospital de Primer Nivel",
+    summary:
+      "Coordinación multidisciplinar de hospital básico con rutas críticas de instalaciones y soporte a licenciamiento.",
+    disciplines: ["Arquitectura", "Estructuras", "MEP"],
+    lodLevels: ["LOD 300", "LOD 400"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Centro hospitalario de primer nivel con estrictos estándares sanitarios y alta densidad de redes técnicas.",
+      options: ["Alta Complejidad"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/hospital/main.webp",
+      imagesByDiscipline: {
+        Arquitectura: "/img/proyectos/hospital/arq.webp",
+        Estructuras: "/img/proyectos/hospital/est.webp",
+        MEP: "/img/proyectos/hospital/mep.webp",
+      },
+      imagesByLOD: {
+        "LOD 300": "/img/proyectos/hospital/lod300.webp",
+        "LOD 400": "/img/proyectos/hospital/lod400.webp",
+      },
+      imagesByDisciplineAndLOD: {
+        Arquitectura: {
+          "LOD 300": "/img/proyectos/hospital/arq-lod300.webp",
+          "LOD 400": "/img/proyectos/hospital/arq-lod400.webp",
+        },
+        Estructuras: {
+          "LOD 300": "/img/proyectos/hospital/est-lod300.webp",
+          "LOD 400": "/img/proyectos/hospital/est-lod400.webp",
+        },
+        MEP: {
+          "LOD 300": "/img/proyectos/hospital/mep-lod300.webp",
+          "LOD 400": "/img/proyectos/hospital/mep-lod400.webp",
+        },
+      },
+      imagesByComplexity: {
+        "Alta Complejidad": "/img/proyectos/hospital/alta-complejidad.webp",
+      },
+    },
+  },
+  {
+    id: "bloque-escolar",
+    name: "Bloque Escolar",
+    summary:
+      "Bloque académico modular con integración de estructura prefabricada y envolvente eficiente.",
+    disciplines: ["Arquitectura", "Estructuras"],
+    lodLevels: ["LOD 200", "LOD 300"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Edificación educativa modular con requerimientos de flexibilidad y rápida ejecución.",
+      options: ["Complejidad Media"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/escolar/main.webp",
+      imagesByDiscipline: {
+        Arquitectura: "/img/proyectos/escolar/arq.webp",
+        Estructuras: "/img/proyectos/escolar/est.webp",
+      },
+      imagesByLOD: {
+        "LOD 200": "/img/proyectos/escolar/lod200.webp",
+        "LOD 300": "/img/proyectos/escolar/lod300.webp",
+      },
+      imagesByComplexity: {
+        "Complejidad Media": "/img/proyectos/escolar/media.webp",
+      },
+    },
+  },
+  {
+    id: "centros-ips",
+    name: "Centros de Atención IPS",
+    summary:
+      "Red de centros de salud para atención primaria con enfoque en replicabilidad y control de calidad.",
+    disciplines: ["Arquitectura"],
+    lodLevels: ["LOD 200", "LOD 300"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Centros de atención IPS distribuidos, con prototipos adaptables a diferentes ubicaciones.",
+      options: ["Complejidad Media"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/ips/main.webp",
+      imagesByDiscipline: {
+        Arquitectura: "/img/proyectos/ips/arq.webp",
+      },
+      imagesByLOD: {
+        "LOD 200": "/img/proyectos/ips/lod200.webp",
+        "LOD 300": "/img/proyectos/ips/lod300.webp",
+      },
+    },
+  },
+  {
+    id: "edificio-multifuncional",
+    name: "Edificio Multifuncional",
+    summary:
+      "Estructura de gran luz para usos mixtos con énfasis en coordinación estructural y logística constructiva.",
+    disciplines: ["Estructuras"],
+    lodLevels: ["LOD 300", "LOD 400"],
+    complexity: {
+      title: "Tipo de Edificio y Complejidad",
+      text: "Edificio multifuncional con grandes luces y cargas variables que demandan ingeniería estructural avanzada.",
+      options: ["Alta Complejidad"],
+    },
+    deliverables: ["IFC", "PDF", "DWG"],
+    images: {
+      main: "/img/proyectos/multifuncional/main.webp",
+      imagesByDiscipline: {
+        Estructuras: "/img/proyectos/multifuncional/est.webp",
+      },
+      imagesByLOD: {
+        "LOD 300": "/img/proyectos/multifuncional/lod300.webp",
+        "LOD 400": "/img/proyectos/multifuncional/lod400.webp",
+      },
+      imagesByComplexity: {
+        "Alta Complejidad": "/img/proyectos/multifuncional/alta.webp",
+      },
+    },
+  },
+]


### PR DESCRIPTION
## Summary
- refactor the BIM deep sections layout to source data from a dedicated data module
- implement reusable UI building blocks for collapsible cards, responsive media/text grids, and simple image carousels
- render LOD levels and executed projects with independent collapsibles, responsive media layouts, and WhatsApp CTAs driven by centralized data

## Testing
- npm run build *(fails: vite executable missing because npm install is blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d8298b96e4832ca3c3c9b0a91deeb4