### PR TITLE
feat: refresh BIM service layout

### DIFF
--- a/src/components/BimDeepSections.jsx
+++ b/src/components/BimDeepSections.jsx
@@ -1,52 +1,53 @@
-import CollapseItem from "./ui/CollapseItem"
-import MediaWithText from "./ui/MediaWithText"
+import ImageFrame from "./ui/ImageFrame"
 import LODSection from "./bim/LODSection"
 import ProjectsSection from "./bim/ProjectsSection"
 import { deepSectionsIntro, pebSection } from "../data/BimDeepSections"
 
 function PebSectionCard() {
   return (
-    <section className="rounded-2xl bg-white p-6 shadow-sm md:p-8">
-      <CollapseItem title={pebSection.title} subtitle={pebSection.summary} defaultOpen>
-        <MediaWithText
-          media={
-            <img
-              src={pebSection.image}
-              alt={pebSection.title}
-              loading="lazy"
-              className="h-full w-full rounded-xl object-cover"
-            />
-          }
-        >
-          <ul className="space-y-3 text-sm text-slate-700 md:text-base">
+    <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-black/5 md:p-8">
+      <header className="space-y-2">
+        <h3 className="text-xl font-semibold text-slate-900 md:text-2xl">{pebSection.title}</h3>
+        <p className="text-sm text-slate-600 md:text-base">{pebSection.summary}</p>
+      </header>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
+        <div className="space-y-3 text-sm text-slate-700 md:text-base lg:col-span-7">
+          <ul className="space-y-3">
             {pebSection.items.map((item, index) => (
               <li key={index} className="flex items-start gap-2">
-                <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-slate-400"></span>
+                <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-emerald-400"></span>
                 <span>{item}</span>
               </li>
             ))}
           </ul>
-        </MediaWithText>
-      </CollapseItem>
+        </div>
+        <div className="lg:col-span-5">
+          <ImageFrame>
+            <img
+              src={pebSection.image}
+              alt={pebSection.title}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          </ImageFrame>
+        </div>
+      </div>
     </section>
   )
 }
 
 export default function BimDeepSections() {
   return (
-    <section className="bg-white py-16">
-      <div className="mx-auto max-w-7xl px-4">
-        <div className="mx-auto max-w-3xl text-center">
-          <h2 className="text-2xl font-bold text-gray-900 md:text-3xl">{deepSectionsIntro.title}</h2>
-          <p className="mt-3 text-gray-600">{deepSectionsIntro.description}</p>
-        </div>
-
-        <div className="mt-10 space-y-6 md:space-y-8">
-          <PebSectionCard />
-          <LODSection />
-          <ProjectsSection />
-        </div>
+    <div className="space-y-8 md:space-y-10">
+      <div className="mx-auto max-w-3xl text-center">
+        <h2 className="text-2xl font-bold text-slate-900 md:text-3xl">{deepSectionsIntro.title}</h2>
+        <p className="mt-3 text-sm text-slate-600 md:text-base">{deepSectionsIntro.description}</p>
       </div>
-    </section>
+
+      <PebSectionCard />
+      <LODSection />
+      <ProjectsSection />
+    </div>
   )
 }

--- a/src/components/bim/LODSection.jsx
+++ b/src/components/bim/LODSection.jsx
@@ -1,63 +1,52 @@
 import CollapseItem from "../ui/CollapseItem"
 import ImageCarousel from "../ui/ImageCarousel"
-import MediaWithText from "../ui/MediaWithText"
 import { lodItems, lodSection } from "../../data/BimDeepSections"
 
-const WHATS_NUMBER = "57XXXXXXXXXX"
+const WHATS_NUMBER = "573127437848"
+const mkWhatsapp = (msg) => `https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(msg)}`
 
-function BrainIcon() {
+function BrainBadge() {
   return (
-    <svg
-      className="h-5 w-5"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M8.5 3.5A3.5 3.5 0 0 0 5 7v2.25c0 .414-.336.75-.75.75h-.5A1.75 1.75 0 0 0 2 11.75v.5c0 .966.784 1.75 1.75 1.75H5" />
-      <path d="M5 14v.75A3.25 3.25 0 0 0 8.25 18H9" />
-      <path d="M15.5 3.5A3.5 3.5 0 0 1 19 7v2.25c0 .414.336.75.75.75h.5A1.75 1.75 0 0 1 22 11.75v.5A1.75 1.75 0 0 1 20.25 14H19" />
-      <path d="M19 14v.75A3.25 3.25 0 0 1 15.75 18H15" />
-      <path d="M9 6.75A2.25 2.25 0 0 1 11.25 4.5H12a2.5 2.5 0 0 1 2.5 2.5V7" />
-      <path d="M9 10.5A2.5 2.5 0 0 0 11.5 13v.5A2.5 2.5 0 0 1 9 16" />
-      <path d="M15 6.75A2.25 2.25 0 0 0 12.75 4.5H12a2.5 2.5 0 0 0-2.5 2.5V7" />
-      <path d="M15 10.5A2.5 2.5 0 0 1 12.5 13v.5A2.5 2.5 0 0 0 15 16" />
-    </svg>
+    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-lg leading-none text-emerald-700">
+      🧠
+    </span>
   )
 }
 
 export default function LODSection() {
   return (
-    <section className="rounded-2xl bg-white p-6 shadow-sm md:p-8">
-      <header>
+    <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-black/5 md:p-8">
+      <header className="space-y-2">
         <h3 className="text-xl font-semibold text-slate-900 md:text-2xl">{lodSection.title}</h3>
-        <p className="mt-2 text-sm text-slate-600 md:text-base">{lodSection.summary}</p>
+        <p className="text-sm text-slate-600 md:text-base">{lodSection.summary}</p>
       </header>
+
       <div className="mt-6 space-y-4 md:space-y-5">
         {lodItems.map((item) => (
           <CollapseItem
             key={item.id}
             title={item.title}
             subtitle={item.short}
-            leadingIcon={<BrainIcon />}
+            leadingIcon={<BrainBadge />}
+            level="main"
+            defaultOpen={false}
           >
-            <MediaWithText
-              media={<ImageCarousel images={item.images} className="mt-4 md:mt-0" />}
-            >
-              <div className="flex flex-col gap-4">
-                <p className="text-slate-600 text-sm leading-6 md:text-base">{item.desc}</p>
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
+              <div className="lg:col-span-7">
+                <p className="text-sm leading-6 text-slate-600 md:text-base">{item.desc}</p>
                 <a
-                  href={`https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(item.whatsMsg)}`}
+                  href={mkWhatsapp(item.whatsMsg)}
                   target="_blank"
-                  rel="noreferrer"
-                  className="text-xs text-slate-500 underline underline-offset-4 transition-colors hover:text-slate-700"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-block text-xs text-slate-500 underline underline-offset-4 transition-colors hover:text-slate-700"
                 >
                   ¿Este nivel encaja con tu proyecto? Escríbenos por WhatsApp
                 </a>
               </div>
-            </MediaWithText>
+              <div className="lg:col-span-5">
+                <ImageCarousel images={item.images} />
+              </div>
+            </div>
           </CollapseItem>
         ))}
       </div>

--- a/src/components/bim/ProjectsSection.jsx
+++ b/src/components/bim/ProjectsSection.jsx
@@ -1,23 +1,9 @@
 import { useMemo, useState } from "react"
 import CollapseItem from "../ui/CollapseItem"
-import MediaWithText from "../ui/MediaWithText"
+import ImageFrame from "../ui/ImageFrame"
 import { executedProjects, projectsSection } from "../../data/BimDeepSections"
 
-function ImageFrame({ src, alt }) {
-  return (
-    <div className="overflow-hidden rounded-xl bg-slate-100">
-      <div className="aspect-video w-full">
-        {src ? (
-          <img src={src} alt={alt} className="h-full w-full object-cover" loading="lazy" />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">Sin vista disponible</div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function OptionPills({ options, active, onChange }) {
+function OptionChips({ options, active, onChange }) {
   if (!options?.length) {
     return null
   }
@@ -31,10 +17,10 @@ function OptionPills({ options, active, onChange }) {
             key={option}
             type="button"
             onClick={() => onChange(option)}
-            className={`rounded-full border px-2 py-1 text-xs font-medium transition-colors ${
+            className={`rounded-full border px-2 py-1 text-xs transition ${
               isActive
                 ? "border-slate-900 bg-slate-900 text-white"
-                : "border-slate-300 text-slate-600 hover:border-slate-400 hover:text-slate-800"
+                : "border-slate-200 text-slate-600 hover:bg-slate-50"
             }`}
           >
             {option}
@@ -46,38 +32,37 @@ function OptionPills({ options, active, onChange }) {
 }
 
 function ProjectItem({ project }) {
-  const [activeDiscipline, setActiveDiscipline] = useState(project.disciplines[0] ?? null)
-  const [activeLOD, setActiveLOD] = useState(project.lodLevels[0] ?? null)
+  const [activeDiscipline, setActiveDiscipline] = useState(project.disciplines?.[0] ?? null)
+  const [activeLOD, setActiveLOD] = useState(project.lodLevels?.[0] ?? null)
   const [activeComplexity, setActiveComplexity] = useState(project.complexity?.options?.[0] ?? null)
 
   const resolvedImage = useMemo(() => {
     const { images } = project
     if (!images) return null
 
-    if (images.imagesByDisciplineAndLOD && activeDiscipline && activeLOD) {
-      const byDiscipline = images.imagesByDisciplineAndLOD[activeDiscipline]
-      const byLod = byDiscipline?.[activeLOD]
-      if (byLod) {
-        return byLod
+    if (activeDiscipline && activeLOD) {
+      const byDisciplineAndLOD = images.imagesByDisciplineAndLOD?.[activeDiscipline]?.[activeLOD]
+      if (byDisciplineAndLOD) {
+        return byDisciplineAndLOD
       }
     }
 
-    if (images.imagesByDiscipline && activeDiscipline) {
-      const byDiscipline = images.imagesByDiscipline[activeDiscipline]
+    if (activeDiscipline) {
+      const byDiscipline = images.imagesByDiscipline?.[activeDiscipline]
       if (byDiscipline) {
         return byDiscipline
       }
     }
 
-    if (images.imagesByLOD && activeLOD) {
-      const byLod = images.imagesByLOD[activeLOD]
-      if (byLod) {
-        return byLod
+    if (activeLOD) {
+      const byLOD = images.imagesByLOD?.[activeLOD]
+      if (byLOD) {
+        return byLOD
       }
     }
 
-    if (images.imagesByComplexity && activeComplexity) {
-      const byComplexity = images.imagesByComplexity[activeComplexity]
+    if (activeComplexity) {
+      const byComplexity = images.imagesByComplexity?.[activeComplexity]
       if (byComplexity) {
         return byComplexity
       }
@@ -87,36 +72,38 @@ function ProjectItem({ project }) {
   }, [project, activeDiscipline, activeLOD, activeComplexity])
 
   return (
-    <CollapseItem title={project.name} subtitle={project.summary} defaultOpen={false}>
-      <MediaWithText media={<ImageFrame src={resolvedImage} alt={project.name} />}>
-        <div className="space-y-4">
+    <CollapseItem title={project.name} level="main" defaultOpen={false}>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
+        <div className="space-y-4 lg:col-span-7">
+          <p className="text-sm leading-6 text-slate-600 md:text-base">{project.intro}</p>
+
           <CollapseItem
             title="Disciplina"
             subtitle="Selecciona la disciplina que quieres analizar"
             level="sub"
-            defaultOpen
+            defaultOpen={false}
           >
-            <OptionPills options={project.disciplines} active={activeDiscipline} onChange={setActiveDiscipline} />
+            <OptionChips options={project.disciplines} active={activeDiscipline} onChange={setActiveDiscipline} />
           </CollapseItem>
 
           <CollapseItem
             title="Nivel de Detalle (LOD)"
             subtitle="Explora cómo evoluciona el modelo"
             level="sub"
-            defaultOpen
+            defaultOpen={false}
           >
-            <OptionPills options={project.lodLevels} active={activeLOD} onChange={setActiveLOD} />
+            <OptionChips options={project.lodLevels} active={activeLOD} onChange={setActiveLOD} />
           </CollapseItem>
 
           <CollapseItem
             title={project.complexity?.title ?? "Tipo de Edificio y Complejidad"}
             subtitle="Contexto del proyecto"
             level="sub"
-            defaultOpen
+            defaultOpen={false}
           >
             <div className="space-y-2 text-xs text-slate-600">
               <p className="leading-5">{project.complexity?.text}</p>
-              <OptionPills
+              <OptionChips
                 options={project.complexity?.options}
                 active={activeComplexity}
                 onChange={setActiveComplexity}
@@ -124,22 +111,32 @@ function ProjectItem({ project }) {
             </div>
           </CollapseItem>
 
-          <p className="text-xs text-slate-500">
-            Entrega final: {project.deliverables?.join(" / ") ?? "IFC / PDF / DWG"}
-          </p>
+          <p className="text-xs text-slate-500">Entregables: {project.deliverables?.join(" / ") ?? "IFC / PDF / DWG"}</p>
         </div>
-      </MediaWithText>
+        <div className="lg:col-span-5">
+          <ImageFrame>
+            {resolvedImage ? (
+              <img src={resolvedImage} alt={project.name} className="h-full w-full object-cover" loading="lazy" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-xs text-slate-500">
+                Sin vista disponible
+              </div>
+            )}
+          </ImageFrame>
+        </div>
+      </div>
     </CollapseItem>
   )
 }
 
 export default function ProjectsSection() {
   return (
-    <section className="rounded-2xl bg-white p-6 shadow-sm md:p-8">
-      <header>
+    <section className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-black/5 md:p-8">
+      <header className="space-y-2">
         <h3 className="text-xl font-semibold text-slate-900 md:text-2xl">{projectsSection.title}</h3>
-        <p className="mt-2 text-sm text-slate-600 md:text-base">{projectsSection.summary}</p>
+        <p className="text-sm text-slate-600 md:text-base">{projectsSection.summary}</p>
       </header>
+
       <div className="mt-6 space-y-4 md:space-y-5">
         {executedProjects.map((project) => (
           <ProjectItem key={project.id} project={project} />

--- a/src/components/ui/CollapseItem.jsx
+++ b/src/components/ui/CollapseItem.jsx
@@ -1,22 +1,24 @@
-import { useState, useMemo, useEffect, useRef } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 const levelStyles = {
   main: {
-    container: "border border-slate-200 rounded-xl bg-slate-50",
-    trigger: "px-4 py-3 md:px-5 md:py-4",
-    title: "text-lg font-semibold text-slate-900",
-    subtitle: "text-sm text-slate-600",
+    container: "rounded-xl border border-slate-200/70 bg-slate-50",
+    header: "py-3 px-3 md:py-4 md:px-4",
+    title: "text-slate-800 text-base md:text-lg font-semibold",
+    subtitle: "text-slate-500 text-sm",
+    body: "px-3 pb-3 md:px-4",
   },
   sub: {
-    container: "border border-slate-200 rounded-lg bg-white",
-    trigger: "px-3 py-2",
-    title: "text-sm font-medium text-slate-900",
-    subtitle: "text-xs text-slate-500",
+    container: "rounded-lg border border-slate-200 bg-white",
+    header: "py-2.5 px-3",
+    title: "text-slate-700 text-sm font-medium",
+    subtitle: "text-slate-500 text-xs",
+    body: "px-3 pb-3",
   },
 }
 
-const chevronBase =
-  "ml-auto flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition-transform duration-300"
+const baseChevronClasses =
+  "flex h-8 w-8 items-center justify-center rounded-full bg-white text-slate-500 transition-transform duration-300 border border-slate-200"
 
 export default function CollapseItem({
   title,
@@ -43,7 +45,7 @@ export default function CollapseItem({
       setMaxHeight(`${height}px`)
       const timeout = setTimeout(() => {
         setMaxHeight("none")
-      }, 300)
+      }, 250)
       return () => clearTimeout(timeout)
     }
 
@@ -57,22 +59,18 @@ export default function CollapseItem({
     <div className={`${styles.container} ${className}`.trim()}>
       <button
         type="button"
-        className={`flex w-full items-center gap-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 ${styles.trigger}`}
+        className={`flex w-full items-center justify-between gap-4 text-left ${styles.header}`}
         onClick={() => setIsOpen((prev) => !prev)}
         aria-expanded={isOpen}
       >
-        {leadingIcon ? (
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-200/70 text-slate-700">
-            {leadingIcon}
-          </span>
-        ) : null}
-        <div className="flex-1">
-          <div className={`flex items-start gap-2 ${leadingIcon ? "mt-0.5" : ""}`}>
-            <span className={styles.title}>{title}</span>
+        <div className="flex flex-1 items-start gap-3">
+          {leadingIcon ? leadingIcon : null}
+          <div className="flex-1">
+            <p className={`${styles.title}`}>{title}</p>
+            {subtitle ? <p className={`${styles.subtitle} mt-1`}>{subtitle}</p> : null}
           </div>
-          {subtitle ? <p className={`${styles.subtitle} mt-1`}>{subtitle}</p> : null}
         </div>
-        <span className={`${chevronBase} ${isOpen ? "rotate-180" : "rotate-0"}`} aria-hidden="true">
+        <span className={`${baseChevronClasses} ${isOpen ? "rotate-180" : "rotate-0"}`} aria-hidden="true">
           <svg
             className="h-4 w-4"
             viewBox="0 0 24 24"
@@ -90,11 +88,11 @@ export default function CollapseItem({
         style={{
           maxHeight: maxHeight === "none" ? undefined : maxHeight,
           overflow: "hidden",
-          transition: "max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s",
+          transition: "max-height 0.25s ease, opacity 0.25s ease",
           opacity: isOpen || maxHeight !== "0px" ? 1 : 0,
         }}
       >
-        <div ref={contentRef} className={`px-4 pb-4 pt-0 md:px-5 ${level === "sub" ? "text-sm" : "text-base"}`}>
+        <div ref={contentRef} className={`${styles.body} pt-0`.trim()}>
           {children}
         </div>
       </div>

--- a/src/components/ui/ImageCarousel.jsx
+++ b/src/components/ui/ImageCarousel.jsx
@@ -1,8 +1,9 @@
-import { useState, useMemo } from "react"
+import { useMemo, useRef, useState } from "react"
 
 export default function ImageCarousel({ images = [], className = "" }) {
   const sanitizedImages = useMemo(() => images.filter(Boolean), [images])
   const [current, setCurrent] = useState(0)
+  const touchStartRef = useRef(null)
 
   if (sanitizedImages.length === 0) {
     return null
@@ -11,8 +12,8 @@ export default function ImageCarousel({ images = [], className = "" }) {
   const goToIndex = (index) => {
     const total = sanitizedImages.length
     if (total === 0) return
-    const nextIndex = (index + total) % total
-    setCurrent(nextIndex)
+    const next = (index + total) % total
+    setCurrent(next)
   }
 
   const handlePrev = () => {
@@ -23,52 +24,102 @@ export default function ImageCarousel({ images = [], className = "" }) {
     goToIndex(current + 1)
   }
 
+  const handleTouchStart = (event) => {
+    if (!event.touches?.length) return
+    touchStartRef.current = event.touches[0].clientX
+  }
+
+  const handleTouchEnd = (event) => {
+    if (touchStartRef.current == null) return
+    const touchEnd = event.changedTouches?.[0]?.clientX
+    if (touchEnd == null) {
+      touchStartRef.current = null
+      return
+    }
+
+    const delta = touchEnd - touchStartRef.current
+    if (Math.abs(delta) > 40) {
+      if (delta > 0) {
+        handlePrev()
+      } else {
+        handleNext()
+      }
+    }
+    touchStartRef.current = null
+  }
+
   return (
-    <div className={`relative w-full overflow-hidden rounded-xl bg-slate-100 ${className}`.trim()}>
-      <div className="aspect-video w-full">
-        <img
-          src={sanitizedImages[current]}
-          alt="Visualización LOD"
-          className="h-full w-full object-cover"
-          loading="lazy"
-        />
-      </div>
+    <div
+      className={`relative aspect-video w-full overflow-hidden rounded-xl bg-slate-100 ${className}`.trim()}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <img
+        src={sanitizedImages[current]}
+        alt="Visualización LOD"
+        className="h-full w-full object-cover"
+        loading="lazy"
+      />
+
       {sanitizedImages.length > 1 ? (
         <>
-          <div className="pointer-events-none absolute inset-y-0 left-0 right-0 flex items-center justify-between p-2">
-            <button
-              type="button"
-              onClick={handlePrev}
-              className="pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-slate-700 shadow"
-              aria-label="Imagen anterior"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path d="m15 6-6 6 6 6" strokeLinecap="round" strokeLinejoin="round" />
+          <button
+            type="button"
+            onClick={handlePrev}
+            className="absolute inset-y-0 left-0 flex items-center px-2 text-slate-700 opacity-70 transition hover:opacity-100"
+            aria-label="Imagen anterior"
+          >
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/80 shadow">
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m15 6-6 6 6 6" />
               </svg>
-            </button>
-            <button
-              type="button"
-              onClick={handleNext}
-              className="pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-slate-700 shadow"
-              aria-label="Imagen siguiente"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path d="m9 6 6 6-6 6" strokeLinecap="round" strokeLinejoin="round" />
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={handleNext}
+            className="absolute inset-y-0 right-0 flex items-center px-2 text-slate-700 opacity-70 transition hover:opacity-100"
+            aria-label="Imagen siguiente"
+          >
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/80 shadow">
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m9 6 6 6-6 6" />
               </svg>
-            </button>
-          </div>
-          <div className="pointer-events-none absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-1">
-            {sanitizedImages.map((_, index) => (
-              <button
-                key={index}
-                type="button"
-                onClick={() => goToIndex(index)}
-                className={`pointer-events-auto h-2.5 w-2.5 rounded-full transition-opacity ${
-                  current === index ? "bg-slate-900 opacity-90" : "bg-white opacity-60"
-                }`}
-                aria-label={`Mostrar imagen ${index + 1}`}
-              />
-            ))}
+            </span>
+          </button>
+
+          <div className="absolute bottom-2 left-1/2 flex -translate-x-1/2 items-center gap-1.5">
+            {sanitizedImages.map((_, index) => {
+              const isActive = index === current
+              return (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => goToIndex(index)}
+                  className={`h-2.5 w-2.5 rounded-full transition ${
+                    isActive ? "bg-slate-900" : "bg-white/80"
+                  }`}
+                  aria-label={`Ir a la imagen ${index + 1}`}
+                />
+              )
+            })}
           </div>
         </>
       ) : null}

--- a/src/components/ui/ImageFrame.jsx
+++ b/src/components/ui/ImageFrame.jsx
@@ -1,0 +1,7 @@
+export default function ImageFrame({ children, className = "" }) {
+  return (
+    <div className={`aspect-video w-full overflow-hidden rounded-xl bg-slate-100 ${className}`.trim()}>
+      {children}
+    </div>
+  )
+}

--- a/src/data/BimDeepSections.jsx
+++ b/src/data/BimDeepSections.jsx
@@ -31,18 +31,15 @@ export const projectsSection = {
     "Experiencia comprobada implementando flujos BIM en proyectos reales de distintas escalas.",
 }
 
+// LODs
 export const lodItems = [
   {
     id: "lod100",
     icon: "brain",
     title: "LOD 100: Idea / Anteproyecto conceptual",
-    short: "Modelo conceptual para evaluar volumen, áreas y alternativas; útil para estimaciones de alto nivel.",
-    desc: "Modelo a nivel conceptual que apoya decisiones tempranas: volumetrías, relaciones espaciales y supuestos de costos/plazos. Útil para evaluar alternativas y riesgos sin comprometer diseño detallado.",
-    images: [
-      "/img/bim/lod100/01.webp",
-      "/img/bim/lod100/02.webp",
-      "/img/bim/lod100/03.webp",
-    ],
+    short: "Modelo conceptual para evaluar volumen, áreas y alternativas.",
+    desc: "Modelo a nivel conceptual que apoya decisiones tempranas (volumetrías, relaciones espaciales y supuestos de costo/plazo). Útil para estimaciones de alto nivel y evaluación de alternativas.",
+    images: ["/img/bim/lod100/01.webp", "/img/bim/lod100/02.webp", "/img/bim/lod100/03.webp"],
     whatsMsg:
       "Hola, me interesa el servicio LOD 100 (Idea/Anteproyecto). ¿Podemos hablar de mi proyecto?",
   },
@@ -50,72 +47,51 @@ export const lodItems = [
     id: "lod200",
     icon: "brain",
     title: "LOD 200: Desarrollo esquemático",
-    short: "Diseño preliminar con geometrías aproximadas y ubicación de sistemas; base para coordinación inicial.",
-    desc: "Modelo que incorpora geometrías aproximadas y ubicación general de sistemas. Permite validar criterios de diseño, estimar cantidades preliminares y preparar la coordinación interdisciplinar inicial.",
-    images: [
-      "/img/bim/lod200/01.webp",
-      "/img/bim/lod200/02.webp",
-      "/img/bim/lod200/03.webp",
-    ],
-    whatsMsg:
-      "Hola, me interesa el servicio LOD 200 (Desarrollo esquemático). ¿Podemos hablar de mi proyecto?",
+    short: "Geometrías aproximadas, ubicación de sistemas y coordinación inicial.",
+    desc: "Diseño preliminar con definiciones aproximadas, ubicación de elementos y base para coordinación temprana entre disciplinas.",
+    images: ["/img/bim/lod200/01.webp"],
+    whatsMsg: "Hola, me interesa el servicio LOD 200.",
   },
   {
     id: "lod300",
     icon: "brain",
     title: "LOD 300: Diseño coordinado",
-    short: "Geometría definida y relaciones precisas; lista para coordinación técnica y extracción confiable de cantidades.",
-    desc: "Modelo con geometría definida, relaciones precisas y especificaciones asociadas. Facilita la coordinación técnica entre disciplinas y permite extraer cantidades confiables para planeación y compras.",
-    images: [
-      "/img/bim/lod300/01.webp",
-      "/img/bim/lod300/02.webp",
-      "/img/bim/lod300/03.webp",
-    ],
-    whatsMsg:
-      "Hola, me interesa el servicio LOD 300 (Diseño coordinado). ¿Podemos hablar de mi proyecto?",
+    short: "Geometría definida y relaciones precisas para extracción confiable de cantidades.",
+    desc: "Geometría y relaciones precisas, listas para coordinación técnica, detección de interferencias y cantidades confiables.",
+    images: ["/img/bim/lod300/01.webp"],
+    whatsMsg: "Hola, me interesa el servicio LOD 300.",
   },
   {
     id: "lod400",
     icon: "brain",
     title: "LOD 400: Construcción y prefabricación",
-    short: "Modelo para construcción y fabricación; incluye detalles y ensamblajes para producción en obra/taller.",
-    desc: "Modelo listo para construcción y prefabricación, con detalles constructivos, secuencias y ensamblajes. Soporta la fabricación en taller y la logística de montaje en obra.",
-    images: [
-      "/img/bim/lod400/01.webp",
-      "/img/bim/lod400/02.webp",
-      "/img/bim/lod400/03.webp",
-    ],
-    whatsMsg:
-      "Hola, me interesa el servicio LOD 400 (Construcción/prefabricación). ¿Podemos hablar de mi proyecto?",
+    short: "Detalles para producción en obra/taller.",
+    desc: "Modelo para fabricación/armado, incluye detalles, uniones y secuencias necesarias para producción.",
+    images: ["/img/bim/lod400/01.webp"],
+    whatsMsg: "Hola, me interesa el servicio LOD 400.",
   },
   {
     id: "lod500",
     icon: "brain",
     title: "LOD 500: Operación y mantenimiento",
-    short: "Modelo conforme a obra (as-built) para operación y mantenimiento.",
-    desc: "Modelo conforme a obra que documenta el estado final del activo. Integra información para operación, mantenimiento preventivo y gestión del ciclo de vida de la infraestructura.",
-    images: [
-      "/img/bim/lod500/01.webp",
-      "/img/bim/lod500/02.webp",
-      "/img/bim/lod500/03.webp",
-    ],
-    whatsMsg:
-      "Hola, me interesa el servicio LOD 500 (Operación/Mantenimiento). ¿Podemos hablar de mi proyecto?",
+    short: "Modelo conforme a obra (as-built) para O&M.",
+    desc: "Modelo verificado en campo, base para operación, mantenimiento, activos y gemelo digital.",
+    images: ["/img/bim/lod500/01.webp"],
+    whatsMsg: "Hola, me interesa el servicio LOD 500.",
   },
 ]
 
+// Proyectos ejecutados
 export const executedProjects = [
   {
     id: "nave-industrial",
     name: "Nave Industrial",
-    summary:
-      "Modelado integral para nave logística con coordinación de estructuras y arquitectura en etapas tempranas.",
+    intro: "Modelado integral con coordinación de estructuras y arquitectura en etapas tempranas.",
     disciplines: ["Arquitectura", "Estructuras"],
     lodLevels: ["LOD 200", "LOD 300"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
       text: "Nave industrial de uso múltiple para almacenamiento y operaciones logísticas ligeras. Pórticos en acero y elementos en concreto reforzado.",
-      options: ["Complejidad Media"],
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -133,14 +109,12 @@ export const executedProjects = [
   {
     id: "vivienda-unifamiliar",
     name: "Vivienda Unifamiliar",
-    summary:
-      "Residencia unifamiliar optimizada para un cronograma acelerado y control de costos desde la fase esquemática.",
+    intro: "Modelado arquitectónico con énfasis en tiempos de entrega y optimización de costos.",
     disciplines: ["Arquitectura"],
     lodLevels: ["LOD 200"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
-      text: "Vivienda unifamiliar de baja complejidad, optimizada para tiempos de obra y costos.",
-      options: ["Baja Complejidad"],
+      text: "Vivienda unifamiliar compacta, diseñada para ejecución ágil y control presupuestal.",
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -152,14 +126,12 @@ export const executedProjects = [
   {
     id: "edificio-residencial",
     name: "Edificio Residencial",
-    summary:
-      "Torre de vivienda multifamiliar con coordinación entre arquitectura y sistemas MEP para mitigación de interferencias.",
+    intro: "Torre de vivienda multifamiliar coordinada entre arquitectura y sistemas MEP.",
     disciplines: ["Arquitectura", "MEP"],
     lodLevels: ["LOD 200", "LOD 300"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
-      text: "Edificio residencial de media altura con énfasis en eficiencia energética y confort interior.",
-      options: ["Complejidad Alta"],
+      text: "Edificio residencial de media altura con foco en eficiencia energética y confort interior.",
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -187,14 +159,12 @@ export const executedProjects = [
   {
     id: "hospital-primer-nivel",
     name: "Hospital de Primer Nivel",
-    summary:
-      "Coordinación multidisciplinar de hospital básico con rutas críticas de instalaciones y soporte a licenciamiento.",
+    intro: "Coordinación multidisciplinar con rutas críticas de instalaciones y soporte a licenciamiento.",
     disciplines: ["Arquitectura", "Estructuras", "MEP"],
     lodLevels: ["LOD 300", "LOD 400"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
-      text: "Centro hospitalario de primer nivel con estrictos estándares sanitarios y alta densidad de redes técnicas.",
-      options: ["Alta Complejidad"],
+      text: "Centro hospitalario básico con altos estándares sanitarios y densidad de redes técnicas.",
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -222,22 +192,17 @@ export const executedProjects = [
           "LOD 400": "/img/proyectos/hospital/mep-lod400.webp",
         },
       },
-      imagesByComplexity: {
-        "Alta Complejidad": "/img/proyectos/hospital/alta-complejidad.webp",
-      },
     },
   },
   {
     id: "bloque-escolar",
     name: "Bloque Escolar",
-    summary:
-      "Bloque académico modular con integración de estructura prefabricada y envolvente eficiente.",
+    intro: "Bloque académico modular con integración de estructura prefabricada y envolvente eficiente.",
     disciplines: ["Arquitectura", "Estructuras"],
     lodLevels: ["LOD 200", "LOD 300"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
       text: "Edificación educativa modular con requerimientos de flexibilidad y rápida ejecución.",
-      options: ["Complejidad Media"],
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -250,22 +215,17 @@ export const executedProjects = [
         "LOD 200": "/img/proyectos/escolar/lod200.webp",
         "LOD 300": "/img/proyectos/escolar/lod300.webp",
       },
-      imagesByComplexity: {
-        "Complejidad Media": "/img/proyectos/escolar/media.webp",
-      },
     },
   },
   {
     id: "centros-ips",
     name: "Centros de Atención IPS",
-    summary:
-      "Red de centros de salud para atención primaria con enfoque en replicabilidad y control de calidad.",
+    intro: "Red de centros de salud con enfoque en replicabilidad y control de calidad.",
     disciplines: ["Arquitectura"],
     lodLevels: ["LOD 200", "LOD 300"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
-      text: "Centros de atención IPS distribuidos, con prototipos adaptables a diferentes ubicaciones.",
-      options: ["Complejidad Media"],
+      text: "Centros de atención primaria con prototipos adaptables a diferentes ubicaciones.",
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -282,14 +242,12 @@ export const executedProjects = [
   {
     id: "edificio-multifuncional",
     name: "Edificio Multifuncional",
-    summary:
-      "Estructura de gran luz para usos mixtos con énfasis en coordinación estructural y logística constructiva.",
+    intro: "Estructura de gran luz enfocada en coordinación estructural y logística constructiva.",
     disciplines: ["Estructuras"],
     lodLevels: ["LOD 300", "LOD 400"],
     complexity: {
       title: "Tipo de Edificio y Complejidad",
-      text: "Edificio multifuncional con grandes luces y cargas variables que demandan ingeniería estructural avanzada.",
-      options: ["Alta Complejidad"],
+      text: "Edificio de usos mixtos con grandes luces y cargas variables que requieren ingeniería avanzada.",
     },
     deliverables: ["IFC", "PDF", "DWG"],
     images: {
@@ -300,9 +258,6 @@ export const executedProjects = [
       imagesByLOD: {
         "LOD 300": "/img/proyectos/multifuncional/lod300.webp",
         "LOD 400": "/img/proyectos/multifuncional/lod400.webp",
-      },
-      imagesByComplexity: {
-        "Alta Complejidad": "/img/proyectos/multifuncional/alta.webp",
       },
     },
   },

--- a/src/pages/Servicios.jsx
+++ b/src/pages/Servicios.jsx
@@ -1,10 +1,12 @@
-import BimDeepSections from "../components/BimDeepSections";
+import BimDeepSections from "../components/BimDeepSections"
 
 export default function ModeladoBIMPage() {
   return (
     <main>
       {/* Aquí tu hero */}
-      <BimDeepSections />
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-8 md:space-y-10">
+        <BimDeepSections />
+      </section>
     </main>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- rework the BIM services section to use the new card layout and responsive 12-column grids
- centralize LOD and project metadata for Modelado BIM and wire it into the updated sections
- add reusable UI pieces for collapsibles, the carousel, and framed media to support the layout

## Testing
- npm run lint *(fails: npm install was blocked by a 403 from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d82f708c30832c8cabce12100bb4b7