### PR TITLE
Refactor BIM service layout with new collapsible sections

### DIFF
--- a/src/components/BimServiceCard.jsx
+++ b/src/components/BimServiceCard.jsx
@@ -6,55 +6,58 @@ export default function BimServiceCard({
   subtitle = "Desarrollamos tus proyectos bajo protocolos BIM para mayor eficiencia y coordinación.",
   phone = "+57 312 743 7848",
   wa = "https://wa.me/573127437848",
+  children,
 }) {
   const base = import.meta.env.BASE_URL;
 
   return (
-    // 1) El rectángulo permite desbordes y tiene las esquinas redondeadas
-    <article className="relative overflow-visible rounded-3xl text-white">
-      {/* Fondo 1: gradiente */}
-      <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-emerald-900 to-emerald-700" />
-      {/* Fondo 2: textura */}
-      <div
-        aria-hidden
-        className="absolute inset-0 rounded-3xl bg-cover bg-center opacity-50 mix-blend-overlay"
-        style={{ backgroundImage: `url(${base}bgverde.png)` }}
-      />
-      {/* Brillo decorativo */}
-      <div className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
-
-      {/* 2) Contenido. OJO: reservamos espacio a la derecha para la imagen absoluta */}
-      <div className="relative p-8 md:p-12 md:pr-[360px]">
-        <div className="flex items-center gap-2">
-          <h2 className="whitespace-pre-line text-5xl md:text-6xl font-extrabold leading-none">
-            {title}
-          </h2>
-        </div>
-        <p className="mt-4 text-lg opacity-90">{subtitle}</p>
-        <p className="mt-2 text-sm opacity-75">
-          Más información escribir al Whatsapp: {phone}
-        </p>
-
-        <div className="mt-6">
-          <a
-            href={wa}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="btn bg-white text-primary hover:bg-gray-100"
-          >
-            Escribir ahora
-          </a>
-        </div>
-      </div>
-
-      {/* 3) Ilustración ABSOLUTA que se sale del rectángulo */}
-      <div className="pointer-events-none absolute hidden md:block -right-1 bottom-0 translate-y-6 z-10">
-        <img
-          src={`${base}bim-edificio.png`}
-          alt="Modelado BIM"
-          className="w-[520px] max-w-none drop-shadow-2xl"
+    <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      {/* HERO VERDE */}
+      <article className="relative overflow-visible rounded-3xl text-white">
+        <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-emerald-900 to-emerald-700" />
+        <div
+          aria-hidden
+          className="absolute inset-0 rounded-3xl bg-cover bg-center opacity-50 mix-blend-overlay"
+          style={{ backgroundImage: `url(${base}bgverde.png)` }}
         />
+        <div className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-white/10 blur-3xl" />
+
+        <div className="relative p-8 md:p-12 md:pr-[360px]">
+          <div className="flex items-center gap-2">
+            <h2 className="whitespace-pre-line text-5xl md:text-6xl font-extrabold leading-none">
+              {title}
+            </h2>
+          </div>
+          <p className="mt-4 text-lg opacity-90">{subtitle}</p>
+          <p className="mt-2 text-sm opacity-75">
+            Más información escribir al Whatsapp: {phone}
+          </p>
+
+          <div className="mt-6">
+            <a
+              href={wa}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn bg-white text-primary hover:bg-gray-100"
+            >
+              Escribir ahora
+            </a>
+          </div>
+        </div>
+
+        <div className="pointer-events-none absolute hidden md:block -right-1 bottom-0 translate-y-6 z-10">
+          <img
+            src={`${base}bim-edificio.png`}
+            alt="Modelado BIM"
+            className="w-[520px] max-w-none drop-shadow-2xl"
+          />
+        </div>
+      </article>
+
+      {/* CONTENIDO INFERIOR (tarjetas blancas) */}
+      <div className="mt-10 grid gap-6 lg:grid-cols-2">
+        {children /* Aquí inyectaremos PEB, LOD y Proyectos como tarjetas */}
       </div>
-    </article>
+    </section>
   );
 }

--- a/src/components/bim/LODList.jsx
+++ b/src/components/bim/LODList.jsx
@@ -1,15 +1,33 @@
-import CollapseItem from '../ui/CollapseItem';
-import ImageCarousel from '../ui/ImageCarousel';
 import { lodItems } from '../../data/BimDeepSections';
+import { useState } from 'react';
 
 const WHATS_NUMBER = '573127437848';
-const mkWhatsapp = (msg) => `https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(msg)}`;
+const mkWsp = (msg) => `https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(msg)}`;
+
+function Collapse({ title, subtitle, children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-xl border border-slate-200/70 bg-slate-50">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between gap-4 py-3 px-3"
+      >
+        <div className="text-left">
+          <div className="text-slate-800 font-semibold">{title}</div>
+          {subtitle && <div className="text-slate-500 text-sm">{subtitle}</div>}
+        </div>
+        <span className={`transition-transform ${open ? 'rotate-180' : ''}`}>⌄</span>
+      </button>
+      {open && <div className="px-3 pb-3">{children}</div>}
+    </div>
+  );
+}
 
 export default function LODList() {
   return (
     <div className="space-y-4">
       {lodItems.map((item) => (
-        <CollapseItem
+        <Collapse
           key={item.id}
           title={
             <span>
@@ -18,14 +36,12 @@ export default function LODList() {
             </span>
           }
           subtitle={item.short}
-          defaultOpen={false}
-          level="main"
         >
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
             <div className="lg:col-span-7">
               <p className="text-slate-600 text-sm md:text-base leading-6">{item.desc}</p>
               <a
-                href={mkWhatsapp(item.whatsMsg)}
+                href={mkWsp(item.whatsMsg)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="mt-3 inline-block text-xs text-slate-500 underline underline-offset-4 hover:text-slate-700"
@@ -34,10 +50,16 @@ export default function LODList() {
               </a>
             </div>
             <div className="lg:col-span-5">
-              <ImageCarousel images={item.images} />
+              <div className="relative aspect-video rounded-xl overflow-hidden bg-slate-100">
+                <img
+                  src={item.images?.[0]}
+                  alt="Visualización LOD"
+                  className="w-full h-full object-cover"
+                />
+              </div>
             </div>
           </div>
-        </CollapseItem>
+        </Collapse>
       ))}
     </div>
   );

--- a/src/components/bim/ProjectsList.jsx
+++ b/src/components/bim/ProjectsList.jsx
@@ -1,12 +1,28 @@
-import { useState } from 'react';
-import CollapseItem from '../ui/CollapseItem';
-import ImageFrame from '../ui/ImageFrame';
 import { executedProjects } from '../../data/BimDeepSections';
+import { useState } from 'react';
 
-function Chip({ active, children, onClick }) {
+function Collapse({ title, subtitle, children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-xl border border-slate-200/70 bg-slate-50">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between gap-4 py-3 px-3"
+      >
+        <div className="text-left">
+          <div className="text-slate-800 font-semibold">{title}</div>
+          {subtitle && <div className="text-slate-500 text-sm">{subtitle}</div>}
+        </div>
+        <span className={`transition-transform ${open ? 'rotate-180' : ''}`}>⌄</span>
+      </button>
+      {open && <div className="px-3 pb-3">{children}</div>}
+    </div>
+  );
+}
+
+function Chip({ active, onClick, children }) {
   return (
     <button
-      type="button"
       onClick={onClick}
       className={`px-2 py-1 rounded-full border text-xs ${active ? 'bg-slate-800 text-white border-slate-800' : 'hover:bg-slate-50'}`}
     >
@@ -19,68 +35,67 @@ export default function ProjectsList() {
   return (
     <div className="space-y-4">
       {executedProjects.map((p) => (
-        <ProjectItem key={p.id} project={p} />
+        <Project key={p.id} p={p} />
       ))}
     </div>
   );
 }
 
-function ProjectItem({ project }) {
-  const [activeDiscipline, setActiveDiscipline] = useState(project.disciplines?.[0] || null);
-  const [activeLOD, setActiveLOD] = useState(project.lodLevels?.[0] || null);
+function Project({ p }) {
+  const [disc, setDisc] = useState(p.disciplines?.[0] || null);
+  const [lod, setLOD] = useState(p.lodLevels?.[0] || null);
 
-  const resolveImage = () => {
-    const imgs = project.images || {};
-    if (imgs.imagesByDisciplineAndLOD?.[activeDiscipline]?.[activeLOD])
-      return imgs.imagesByDisciplineAndLOD[activeDiscipline][activeLOD];
-    if (imgs.imagesByDiscipline?.[activeDiscipline]) return imgs.imagesByDiscipline[activeDiscipline];
-    if (imgs.imagesByLOD?.[activeLOD]) return imgs.imagesByLOD[activeLOD];
-    return imgs.main || '';
-  };
+  const img = (() => {
+    const i = p.images || {};
+    if (i.imagesByDisciplineAndLOD?.[disc]?.[lod]) return i.imagesByDisciplineAndLOD[disc][lod];
+    if (i.imagesByDiscipline?.[disc]) return i.imagesByDiscipline[disc];
+    if (i.imagesByLOD?.[lod]) return i.imagesByLOD[lod];
+    return i.main || '';
+  })();
 
   return (
-    <CollapseItem title={project.name} subtitle={project.intro} level="main" defaultOpen={false}>
+    <Collapse title={p.name} subtitle={p.intro}>
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
         <div className="lg:col-span-7 space-y-4">
-          {project.disciplines?.length ? (
-            <CollapseItem title="Disciplina" level="sub">
+          {p.disciplines?.length ? (
+            <Collapse title="Disciplina">
               <div className="flex flex-wrap gap-2">
-                {project.disciplines.map((d) => (
-                  <Chip key={d} active={d === activeDiscipline} onClick={() => setActiveDiscipline(d)}>
+                {p.disciplines.map((d) => (
+                  <Chip key={d} active={d === disc} onClick={() => setDisc(d)}>
                     {d}
                   </Chip>
                 ))}
               </div>
-            </CollapseItem>
+            </Collapse>
           ) : null}
 
-          {project.lodLevels?.length ? (
-            <CollapseItem title="Nivel de Detalle (LOD)" level="sub">
+          {p.lodLevels?.length ? (
+            <Collapse title="Nivel de Detalle (LOD)">
               <div className="flex flex-wrap gap-2">
-                {project.lodLevels.map((l) => (
-                  <Chip key={l} active={l === activeLOD} onClick={() => setActiveLOD(l)}>
+                {p.lodLevels.map((l) => (
+                  <Chip key={l} active={l === lod} onClick={() => setLOD(l)}>
                     {l}
                   </Chip>
                 ))}
               </div>
-            </CollapseItem>
+            </Collapse>
           ) : null}
 
-          {project.complexity?.text ? (
-            <CollapseItem title={project.complexity.title || 'Tipo de Edificio y Complejidad'} level="sub" defaultOpen={false}>
-              <p className="text-slate-600 text-sm leading-6">{project.complexity.text}</p>
-            </CollapseItem>
+          {p.complexity?.text ? (
+            <Collapse title={p.complexity.title || 'Tipo de Edificio y Complejidad'}>
+              <p className="text-slate-600 text-sm leading-6">{p.complexity.text}</p>
+            </Collapse>
           ) : null}
 
-          <p className="text-xs text-slate-500">Entregables: {(project.deliverables || ['IFC', 'PDF', 'DWG']).join(' / ')}</p>
+          <p className="text-xs text-slate-500">Entregables: {(p.deliverables || ['IFC', 'PDF', 'DWG']).join(' / ')}</p>
         </div>
 
         <div className="lg:col-span-5">
-          <ImageFrame>
-            <img src={resolveImage()} alt={project.name} className="w-full h-full object-cover" />
-          </ImageFrame>
+          <div className="aspect-video rounded-xl overflow-hidden bg-slate-100">
+            <img src={img} alt={p.name} className="w-full h-full object-cover" />
+          </div>
         </div>
       </div>
-    </CollapseItem>
+    </Collapse>
   );
 }

--- a/src/pages/ModeladoBIMPage.jsx
+++ b/src/pages/ModeladoBIMPage.jsx
@@ -1,10 +1,8 @@
 import React from "react"
 import SEO from "../components/SEO.jsx"
 import BimServiceCard from "../components/BimServiceCard.jsx"
-import ServiceCard from "../components/ServiceCard.jsx"
-import ExpandableCard from "../components/ExpandableCard.jsx"
-import FormatsGrid from "../components/FormatsGrid.jsx"
-import BimDeepSections from "../components/BimDeepSections.jsx"
+import LODList from "../components/bim/LODList.jsx"
+import ProjectsList from "../components/bim/ProjectsList.jsx"
 
 const SITE_URL = "https://civilespro.com"
 
@@ -23,31 +21,6 @@ export default function ModeladoBIMPage() {
     description:
       "Integramos todas las disciplinas de un proyecto bajo estándares BIM, asegurando coordinación y eficiencia de principio a fin.",
   }
-
-  const pebItems = [
-    "Definición de roles y responsabilidades.",
-    "Procesos de trabajo colaborativos.",
-    "Estándares y normas internacionales.",
-    "Entregables BIM claros y estructurados.",
-  ]
-
-  const lodItems = [
-    "LOD 100: Idea / Anteproyecto conceptual.",
-    "LOD 200: Diseño preliminar.",
-    "LOD 300: Geometría precisa y coordinación.",
-    "LOD 400: Construcción y documentación.",
-    "LOD 500: Proyecto final para operación y mantenimiento.",
-  ]
-
-  const projectItems = [
-    "Nave Industrial (Arquitectura + Estructuras).",
-    "Vivienda Unifamiliar (Arquitectura).",
-    "Edificio Residencial (Arquitectura + MEP).",
-    "Hospital de Primer Nivel (Arquitectura + Estructuras + MEP).",
-    "Bloque Escolar (Arquitectura + Estructuras).",
-    "Centros de Atención IPS (Arquitectura).",
-    "Edificio Multifuncional (Estructuras).",
-  ]
 
   return (
     <>
@@ -87,23 +60,41 @@ export default function ModeladoBIMPage() {
             <BimServiceCard
               title={"Modelado BIM\nbajo protocolos ISO 19650"}
               subtitle="Integramos todas las disciplinas en un solo proyecto, asegurando eficiencia y coordinación desde la etapa conceptual hasta la construcción."
-            />
-          </div>
+            >
+              {/* Tarjeta PEB */}
+              <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8">
+                <h3 className="text-lg font-semibold">Planes de Ejecución BIM (PEB)</h3>
+                <ul className="mt-4 space-y-2 text-slate-700">
+                  <li>✓ Definición de roles y responsabilidades.</li>
+                  <li>✓ Procesos de trabajo colaborativos.</li>
+                  <li>✓ Estándares y normas internacionales.</li>
+                  <li>✓ Entregables BIM claros y estructurados.</li>
+                </ul>
+              </div>
 
-          <div className="mt-10 grid gap-6 lg:grid-cols-2">
-            <ServiceCard title="Planes de Ejecución BIM (PEB)" items={pebItems} />
+              {/* Tarjeta LOD con colapsables por nivel */}
+              <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8">
+                <h3 className="text-lg font-semibold">LOD – Niveles de Desarrollo</h3>
+                <p className="text-slate-600 text-sm">Adaptamos el nivel de detalle según la etapa del proyecto.</p>
+                <div className="mt-4">
+                  {/* contenido puro, sin tarjeta adicional */}
+                  <LODList />
+                </div>
+              </div>
 
-            <ExpandableCard
-              title="LOD – Niveles de Desarrollo"
-              intro="Adaptamos el nivel de detalle según la etapa del proyecto."
-              items={lodItems}
-            />
+              {/* Tarjeta Proyectos Ejecutados */}
+              <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8 lg:col-span-2">
+                <h3 className="text-lg font-semibold">Proyectos Ejecutados</h3>
+                <p className="text-slate-600 text-sm">Experiencia comprobada en distintas escalas.</p>
+                <div className="mt-4">
+                  {/* contenido puro, sin tarjeta adicional */}
+                  <ProjectsList />
+                </div>
+              </div>
 
-            <ServiceCard title="Proyectos Ejecutados" items={projectItems} />
-
-            <div className="lg:col-span-2">
-              <FormatsGrid />
-            </div>
+              {/* Tarjeta Entregables (si la usas) */}
+              {/* <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8 lg:col-span-2">...</div> */}
+            </BimServiceCard>
           </div>
         </div>
       </section>
@@ -125,7 +116,6 @@ export default function ModeladoBIMPage() {
         </div>
       </section>
 
-      <BimDeepSections />
     </>
   )
 }

--- a/src/pages/Servicios.jsx
+++ b/src/pages/Servicios.jsx
@@ -1,11 +1,14 @@
-import BimDeepSections from "../components/BimDeepSections"
-
 export default function ModeladoBIMPage() {
   return (
     <main>
       {/* Aquí tu hero */}
-      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-8 md:space-y-10">
-        <BimDeepSections />
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+        <div className="rounded-3xl bg-slate-900/5 p-10 text-center">
+          <h1 className="text-3xl font-bold text-slate-900">Servicios BIM</h1>
+          <p className="mt-3 text-slate-600">
+            Estamos renovando esta sección. Mientras tanto, visita <a href="/modelado-bim" className="underline">modelado-bim</a> para conocer el detalle de nuestro servicio.
+          </p>
+        </div>
       </section>
     </main>
   )


### PR DESCRIPTION
## Summary
- turn `BimServiceCard` into a layout wrapper that keeps the hero and adds a grid slot for service cards
- rebuild the LOD and Projects lists as standalone collapsible content blocks fed from the shared BIM data
- embed the new cards on `/modelado-bim` and remove duplicated `BimDeepSections` usage, updating `/servicios` to avoid the old render

## Testing
- npm run build *(fails: vite not found because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d85b3bb024832c82b7cb201a8c7a62