### PR TITLE
Add reusable toolbar controls to LOD and projects sections

### DIFF
--- a/src/components/bim/LODList.jsx
+++ b/src/components/bim/LODList.jsx
@@ -1,11 +1,41 @@
-import { lodItems } from '../../data/BimDeepSections';
-import { useState } from 'react';
+import { useMemo, useRef, useEffect, useState } from "react";
+import { lodItems } from "@/data/BimDeepSections";
 
-const WHATS_NUMBER = '573127437848';
+const WHATS_NUMBER = "573127437848";
 const mkWsp = (msg) => `https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(msg)}`;
 
-function Collapse({ title, subtitle, children }) {
-  const [open, setOpen] = useState(false);
+export function filterLODItemsByQuery(items = lodItems, query = "") {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+  return items.filter((it) => (it.title + it.short + it.desc).toLowerCase().includes(q));
+}
+
+export function filterLODItemsByLevels(items = lodItems, activeLevels = new Set()) {
+  if (!activeLevels || !activeLevels.size) return items;
+  return items.filter((it) => activeLevels.has(it.id));
+}
+
+export function expandAllLODItems(items = lodItems) {
+  return items.reduce((acc, item) => {
+    acc[item.id] = true;
+    return acc;
+  }, {});
+}
+
+export function collapseAllLODItems(items = lodItems) {
+  return items.reduce((acc, item) => {
+    acc[item.id] = false;
+    return acc;
+  }, {});
+}
+
+function Collapse({ title, subtitle, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    setOpen(defaultOpen);
+  }, [defaultOpen]);
+
   return (
     <div className="rounded-xl border border-slate-200/70 bg-slate-50">
       <button
@@ -16,17 +46,38 @@ function Collapse({ title, subtitle, children }) {
           <div className="text-slate-800 font-semibold">{title}</div>
           {subtitle && <div className="text-slate-500 text-sm">{subtitle}</div>}
         </div>
-        <span className={`transition-transform ${open ? 'rotate-180' : ''}`}>⌄</span>
+        <span className={`transition-transform ${open ? "rotate-180" : ""}`}>⌄</span>
       </button>
       {open && <div className="px-3 pb-3">{children}</div>}
     </div>
   );
 }
 
-export default function LODList() {
+export default function LODList({ query = "", activeLevels = new Set(), expandAll = false, onItemRef }) {
+  const refs = useRef({});
+
+  const filtered = useMemo(() => {
+    const byQuery = filterLODItemsByQuery(lodItems, query);
+    return filterLODItemsByLevels(byQuery, activeLevels);
+  }, [query, activeLevels]);
+
+  useEffect(() => {
+    if (!onItemRef) return;
+    const map = filtered.reduce((acc, item) => {
+      acc[item.id] = () => {
+        const el = refs.current[item.id];
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      };
+      return acc;
+    }, {});
+    onItemRef(map);
+  }, [filtered, onItemRef]);
+
   return (
     <div className="space-y-4">
-      {lodItems.map((item) => (
+      {filtered.map((item) => (
         <Collapse
           key={item.id}
           title={
@@ -36,8 +87,18 @@ export default function LODList() {
             </span>
           }
           subtitle={item.short}
+          defaultOpen={expandAll}
         >
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
+          <div
+            ref={(el) => {
+              if (el) {
+                refs.current[item.id] = el;
+              } else {
+                delete refs.current[item.id];
+              }
+            }}
+            className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8"
+          >
             <div className="lg:col-span-7">
               <p className="text-slate-600 text-sm md:text-base leading-6">{item.desc}</p>
               <a

--- a/src/components/bim/ProjectsList.jsx
+++ b/src/components/bim/ProjectsList.jsx
@@ -1,8 +1,13 @@
-import { executedProjects } from '../../data/BimDeepSections';
-import { useState } from 'react';
+import { useState, useEffect } from "react";
+import { executedProjects } from "@/data/BimDeepSections";
 
-function Collapse({ title, subtitle, children }) {
-  const [open, setOpen] = useState(false);
+function Collapse({ title, subtitle, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    setOpen(defaultOpen);
+  }, [defaultOpen]);
+
   return (
     <div className="rounded-xl border border-slate-200/70 bg-slate-50">
       <button
@@ -13,7 +18,7 @@ function Collapse({ title, subtitle, children }) {
           <div className="text-slate-800 font-semibold">{title}</div>
           {subtitle && <div className="text-slate-500 text-sm">{subtitle}</div>}
         </div>
-        <span className={`transition-transform ${open ? 'rotate-180' : ''}`}>⌄</span>
+        <span className={`transition-transform ${open ? "rotate-180" : ""}`}>⌄</span>
       </button>
       {open && <div className="px-3 pb-3">{children}</div>}
     </div>
@@ -24,37 +29,63 @@ function Chip({ active, onClick, children }) {
   return (
     <button
       onClick={onClick}
-      className={`px-2 py-1 rounded-full border text-xs ${active ? 'bg-slate-800 text-white border-slate-800' : 'hover:bg-slate-50'}`}
+      className={`px-2 py-1 rounded-full border text-xs ${active ? "bg-slate-800 text-white border-slate-800" : "hover:bg-slate-50"}`}
     >
       {children}
     </button>
   );
 }
 
-export default function ProjectsList() {
+export default function ProjectsList({
+  query = "",
+  filterDisciplines = new Set(),
+  filterLOD = new Set(),
+  expandAll = false,
+}) {
+  const q = query.trim().toLowerCase();
+  const list = executedProjects.filter((p) => {
+    const txt = (p.name + (p.intro || "")).toLowerCase();
+    const hitText = !q || txt.includes(q);
+    const hitDisc = !filterDisciplines.size || (p.disciplines || []).some((d) => filterDisciplines.has(d));
+    const hitLOD = !filterLOD.size || (p.lodLevels || []).some((l) => filterLOD.has(l));
+    return hitText && hitDisc && hitLOD;
+  });
+
   return (
     <div className="space-y-4">
-      {executedProjects.map((p) => (
-        <Project key={p.id} p={p} />
+      {list.map((p) => (
+        <Project key={p.id} p={p} defaultOpen={expandAll} />
       ))}
     </div>
   );
 }
 
-function Project({ p }) {
+function Project({ p, defaultOpen }) {
   const [disc, setDisc] = useState(p.disciplines?.[0] || null);
   const [lod, setLOD] = useState(p.lodLevels?.[0] || null);
+
+  useEffect(() => {
+    if (p.disciplines?.length && !p.disciplines.includes(disc)) {
+      setDisc(p.disciplines[0]);
+    }
+  }, [p.disciplines, disc]);
+
+  useEffect(() => {
+    if (p.lodLevels?.length && !p.lodLevels.includes(lod)) {
+      setLOD(p.lodLevels[0]);
+    }
+  }, [p.lodLevels, lod]);
 
   const img = (() => {
     const i = p.images || {};
     if (i.imagesByDisciplineAndLOD?.[disc]?.[lod]) return i.imagesByDisciplineAndLOD[disc][lod];
     if (i.imagesByDiscipline?.[disc]) return i.imagesByDiscipline[disc];
     if (i.imagesByLOD?.[lod]) return i.imagesByLOD[lod];
-    return i.main || '';
+    return i.main || "";
   })();
 
   return (
-    <Collapse title={p.name} subtitle={p.intro}>
+    <Collapse title={p.name} subtitle={p.intro} defaultOpen={defaultOpen}>
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
         <div className="lg:col-span-7 space-y-4">
           {p.disciplines?.length ? (
@@ -82,12 +113,12 @@ function Project({ p }) {
           ) : null}
 
           {p.complexity?.text ? (
-            <Collapse title={p.complexity.title || 'Tipo de Edificio y Complejidad'}>
+            <Collapse title={p.complexity.title || "Tipo de Edificio y Complejidad"}>
               <p className="text-slate-600 text-sm leading-6">{p.complexity.text}</p>
             </Collapse>
           ) : null}
 
-          <p className="text-xs text-slate-500">Entregables: {(p.deliverables || ['IFC', 'PDF', 'DWG']).join(' / ')}</p>
+          <p className="text-xs text-slate-500">Entregables: {(p.deliverables || ["IFC", "PDF", "DWG"]).join(" / ")}</p>
         </div>
 
         <div className="lg:col-span-5">

--- a/src/components/ui/SectionToolbar.jsx
+++ b/src/components/ui/SectionToolbar.jsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from "react";
+
+export default function SectionToolbar({
+  onSearch,
+  searchPlaceholder = "Buscar…",
+  leftChips = [],
+  rightChips = [],
+  showExpandToggle = false,
+  expanded = false,
+  onToggleExpand,
+  className = "",
+}) {
+  const [q, setQ] = useState("");
+
+  useEffect(() => {
+    if (onSearch) onSearch(q);
+  }, [q]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className={`flex flex-col gap-3 md:flex-row md:items-center md:justify-between ${className}`}>
+      {/* IZQUIERDA: chips + buscador */}
+      <div className="flex flex-1 flex-wrap items-center gap-2">
+        {leftChips.map((ch) => (
+          <button
+            key={ch.id}
+            type="button"
+            onClick={ch.onClick}
+            className={`px-2 py-1 rounded-full border text-xs transition
+              ${ch.active ? "bg-slate-800 text-white border-slate-800" : "hover:bg-slate-50"}`}
+          >
+            {ch.label}
+          </button>
+        ))}
+        <div className="relative ml-auto md:ml-4 w-full md:w-64">
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="w-full rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-emerald-500/30"
+          />
+        </div>
+      </div>
+
+      {/* DERECHA: chips y expandir/colapsar */}
+      <div className="flex items-center gap-2">
+        {rightChips.map((ch) => (
+          <button
+            key={ch.id}
+            type="button"
+            onClick={ch.onClick}
+            className={`px-2 py-1 rounded-full border text-xs transition
+              ${ch.active ? "bg-slate-800 text-white border-slate-800" : "hover:bg-slate-50"}`}
+          >
+            {ch.label}
+          </button>
+        ))}
+        {showExpandToggle && (
+          <button
+            type="button"
+            onClick={onToggleExpand}
+            className="px-2 py-1 rounded-full border text-xs hover:bg-slate-50"
+            aria-pressed={expanded}
+          >
+            {expanded ? "Colapsar todo" : "Expandir todo"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,15 @@
-import { defineConfig } from "vite"
-import react from "@vitejs/plugin-react"
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   server: {
     port: 5173,
     proxy: {
@@ -13,4 +19,4 @@ export default defineConfig({
       },
     },
   },
-})
+});


### PR DESCRIPTION
## Summary
- add a reusable SectionToolbar component with search, chip filters, and expand toggles
- enhance LOD and Projects listings to support filtering, expand-all behavior, and smooth scrolling hooks
- integrate the new toolbar into the BIM service cards and configure a src alias for cleaner imports

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies cannot be installed in the sandbox registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d85e6a8028832ca0a4460d0a184270