### PR TITLE
Add Notion-style LOD card to BIM page

### DIFF
--- a/src/components/bim/LODNotionCard.jsx
+++ b/src/components/bim/LODNotionCard.jsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from 'react';
+import { lodItems } from '@/data/BimDeepSections';
+
+const WHATS_NUMBER = '573127437848';
+const mkWsp = (msg) => `https://wa.me/${WHATS_NUMBER}?text=${encodeURIComponent(msg)}`;
+
+export default function LODNotionCard() {
+  // LOD activo (para el preview de la derecha)
+  const [activeId, setActiveId] = useState(lodItems?.[0]?.id || null);
+  const [openDetail, setOpenDetail] = useState(() => new Set()); // ids abiertos (ver detalle)
+  const [imageOverrides, setImageOverrides] = useState({});
+
+  const active = useMemo(() => lodItems.find((x) => x.id === activeId) || null, [activeId]);
+  const displayImages = active ? imageOverrides[active.id] || active.images || [] : [];
+
+  const toggleDetail = (id) => {
+    const n = new Set(openDetail);
+    n.has(id) ? n.delete(id) : n.add(id);
+    setOpenDetail(n);
+  };
+
+  return (
+    <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8 lg:col-span-2">
+      {/* Header del card */}
+      <h3 className="text-xl md:text-2xl font-bold text-slate-900">LOD – Niveles de Desarrollo</h3>
+      <p className="mt-1 text-slate-600">
+        Adaptamos el nivel de detalle según la etapa del proyecto.
+      </p>
+
+      {/* Layout Notion: lista izquierda (60%) + preview derecha (40%) */}
+      <div className="mt-6 grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
+        {/* Lista */}
+        <div className="lg:col-span-7">
+          <ul className="space-y-3">
+            {lodItems.map((item) => {
+              const isOpen = openDetail.has(item.id);
+              const isActive = item.id === activeId;
+              return (
+                <li
+                  key={item.id}
+                  className={`rounded-xl border border-slate-200 bg-white transition hover:bg-slate-50 ${
+                    isActive ? 'ring-1 ring-emerald-300/50' : ''
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setActiveId(item.id)}
+                    className="w-full text-left px-4 py-3 flex items-start gap-3"
+                    aria-pressed={isActive}
+                  >
+                    <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100">🧠</span>
+                    <div>
+                      <div className="font-semibold text-slate-900">{item.title}</div>
+                      <div className="text-sm text-slate-600">{item.short}</div>
+                    </div>
+                    <div className="ml-auto pl-2">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleDetail(item.id);
+                        }}
+                        className="text-slate-500 hover:text-slate-700"
+                        aria-expanded={isOpen}
+                        aria-controls={`lod-detail-${item.id}`}
+                        title="Ver detalle"
+                      >
+                        {isOpen ? '▴' : '▾'}
+                      </button>
+                    </div>
+                  </button>
+
+                  {/* Detalle plano (sin sub-card) */}
+                  {isOpen && (
+                    <div id={`lod-detail-${item.id}`} className="px-4 pb-4 -mt-1">
+                      <p className="text-sm leading-6 text-slate-700">{item.desc}</p>
+                      <a
+                        href={mkWsp(item.whatsMsg || `Hola, me interesa ${item.title}`)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-2 inline-block text-xs text-slate-500 underline underline-offset-4 hover:text-slate-700"
+                      >
+                        ¿Este nivel encaja con tu proyecto? Escríbenos por WhatsApp
+                      </a>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        {/* Preview derecha */}
+        <div className="lg:col-span-5">
+          <div className="aspect-video rounded-xl overflow-hidden bg-slate-100 ring-1 ring-slate-200/60">
+            {displayImages?.[0] ? (
+              <img
+                src={displayImages[0]}
+                alt={active?.title || 'Visualización LOD'}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="h-full w-full flex items-center justify-center text-slate-400 text-sm">
+                Visualización LOD
+              </div>
+            )}
+          </div>
+          {/* Mini thumbs opcionales */}
+          {displayImages.length > 1 && (
+            <div className="mt-3 flex gap-2 overflow-x-auto">
+              {displayImages.map((src, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => {
+                    if (!active) return;
+                    // Reordenar para mostrar elegida primero
+                    setImageOverrides((prev) => {
+                      const base = prev[active.id] || active.images || [];
+                      const reordered = [src, ...base.filter((s) => s !== src)];
+                      return {
+                        ...prev,
+                        [active.id]: reordered,
+                      };
+                    });
+                  }}
+                  className="h-12 w-20 shrink-0 rounded-lg overflow-hidden ring-1 ring-slate-200/70"
+                >
+                  <img src={src} alt="" className="w-full h-full object-cover" />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ModeladoBIMPage.jsx
+++ b/src/pages/ModeladoBIMPage.jsx
@@ -1,135 +1,9 @@
-import React, { useMemo, useRef, useState } from "react";
+import React from "react";
 import SEO from "../components/SEO.jsx";
 import BimServiceCard from "../components/BimServiceCard.jsx";
-import LODList from "../components/bim/LODList.jsx";
-import ProjectsList from "../components/bim/ProjectsList.jsx";
-import SectionToolbar from "@/components/ui/SectionToolbar.jsx";
-import { lodItems, executedProjects } from "@/data/BimDeepSections";
+import LODNotionCard from "@/components/bim/LODNotionCard.jsx";
 
 const SITE_URL = "https://civilespro.com";
-const ALL_LEVELS = lodItems.map((item) => item.id);
-
-function LodCardBody() {
-  const [q, setQ] = useState("");
-  const [expandAll, setExpandAll] = useState(false);
-  const [active, setActive] = useState(new Set());
-  const scrollHandlersRef = useRef({});
-
-  const chips = ALL_LEVELS.map((id) => ({
-    id,
-    label: id.replace("lod", "LOD "),
-    active: active.has(id),
-    onClick: () => {
-      setActive((prev) => {
-        const next = new Set(prev);
-        if (next.has(id)) {
-          next.delete(id);
-        } else {
-          next.add(id);
-          const handler = scrollHandlersRef.current?.[id];
-          if (handler) handler();
-        }
-        return next;
-      });
-    },
-  }));
-
-  return (
-    <>
-      <SectionToolbar
-        onSearch={setQ}
-        searchPlaceholder="Buscar en LOD…"
-        leftChips={chips}
-        showExpandToggle
-        expanded={expandAll}
-        onToggleExpand={() => setExpandAll((v) => !v)}
-        className="mb-4"
-      />
-      <LODList
-        query={q}
-        activeLevels={active}
-        expandAll={expandAll}
-        onItemRef={(map) => {
-          scrollHandlersRef.current = map;
-        }}
-      />
-    </>
-  );
-}
-
-function ProjectsCardBody() {
-  const [q, setQ] = useState("");
-  const [expandAll, setExpandAll] = useState(false);
-
-  const allDisc = useMemo(() => {
-    const s = new Set();
-    executedProjects.forEach((p) => (p.disciplines || []).forEach((d) => s.add(d)));
-    return Array.from(s);
-  }, []);
-  const allLOD = useMemo(() => {
-    const s = new Set();
-    executedProjects.forEach((p) => (p.lodLevels || []).forEach((l) => s.add(l)));
-    return Array.from(s);
-  }, []);
-
-  const [actDisc, setActDisc] = useState(new Set());
-  const [actLOD, setActLOD] = useState(new Set());
-
-  const discChips = allDisc.map((d) => ({
-    id: `disc:${d}`,
-    label: d,
-    active: actDisc.has(d),
-    onClick: () => {
-      setActDisc((prev) => {
-        const next = new Set(prev);
-        if (next.has(d)) {
-          next.delete(d);
-        } else {
-          next.add(d);
-        }
-        return next;
-      });
-    },
-  }));
-
-  const lodChips = allLOD.map((l) => ({
-    id: `lod:${l}`,
-    label: l,
-    active: actLOD.has(l),
-    onClick: () => {
-      setActLOD((prev) => {
-        const next = new Set(prev);
-        if (next.has(l)) {
-          next.delete(l);
-        } else {
-          next.add(l);
-        }
-        return next;
-      });
-    },
-  }));
-
-  return (
-    <>
-      <SectionToolbar
-        onSearch={setQ}
-        searchPlaceholder="Buscar proyectos…"
-        leftChips={discChips}
-        rightChips={lodChips}
-        showExpandToggle
-        expanded={expandAll}
-        onToggleExpand={() => setExpandAll((v) => !v)}
-        className="mb-4"
-      />
-      <ProjectsList
-        query={q}
-        filterDisciplines={actDisc}
-        filterLOD={actLOD}
-        expandAll={expandAll}
-      />
-    </>
-  );
-}
 
 export default function ModeladoBIMPage() {
   const jsonLd = {
@@ -187,39 +61,12 @@ export default function ModeladoBIMPage() {
               title={"Modelado BIM\nbajo protocolos ISO 19650"}
               subtitle="Integramos todas las disciplinas en un solo proyecto, asegurando eficiencia y coordinación desde la etapa conceptual hasta la construcción."
             >
-              {/* Tarjeta PEB */}
-              <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8">
-                <h3 className="text-lg font-semibold">Planes de Ejecución BIM (PEB)</h3>
-                <ul className="mt-4 space-y-2 text-slate-700">
-                  <li>✓ Definición de roles y responsabilidades.</li>
-                  <li>✓ Procesos de trabajo colaborativos.</li>
-                  <li>✓ Estándares y normas internacionales.</li>
-                  <li>✓ Entregables BIM claros y estructurados.</li>
-                </ul>
-              </div>
+              {/* ✅ Card LOD a ancho completo */}
+              <LODNotionCard />
 
-              {/* Tarjeta LOD con colapsables por nivel */}
-              <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8">
-                <h3 className="text-lg font-semibold">LOD – Niveles de Desarrollo</h3>
-                <p className="text-slate-600 text-sm">Adaptamos el nivel de detalle según la etapa del proyecto.</p>
-                <div className="mt-4">
-                  {/* contenido puro, sin tarjeta adicional */}
-                  <LodCardBody />
-                </div>
-              </div>
-
-              {/* Tarjeta Proyectos Ejecutados */}
-              <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8 lg:col-span-2">
-                <h3 className="text-lg font-semibold">Proyectos Ejecutados</h3>
-                <p className="text-slate-600 text-sm">Experiencia comprobada en distintas escalas.</p>
-                <div className="mt-4">
-                  {/* contenido puro, sin tarjeta adicional */}
-                  <ProjectsCardBody />
-                </div>
-              </div>
-
-              {/* Tarjeta Entregables (si la usas) */}
-              {/* <div className="rounded-2xl bg-white shadow-sm ring-1 ring-black/5 p-6 md:p-8 lg:col-span-2">...</div> */}
+              {/* (Deja comentado por ahora; luego lo modernizamos igual)
+              <ProjectsNotionCard />
+              */}
             </BimServiceCard>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the BIM modeling service content with a full-width Notion-style LOD card
- add a dedicated `LODNotionCard` component with detail toggles, WhatsApp CTA, and preview thumbs

## Testing
- npm install *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d86254a29c832c977746bae7a374e1