### PR TITLE
Configure strict CORS for PayPal API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import os
-
-from fastapi import FastAPI, Response
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .database import init_db
@@ -15,47 +13,17 @@ init_db()
 app = FastAPI(title="Civiles Pro API", version="1.0.0")
 
 
-DEFAULT_ALLOWED_ORIGINS = {
-    "http://localhost:5173",
-    "https://civilespro.com",
-    "https://www.civilespro.com",
-    "https://app.civilespro.com",
-    "https://<tu-dominio-frontend>.vercel.app",
-    "https://<tu-dominio-frontend>.netlify.app",
-}
-
-
-def _get_allowed_origins() -> list[str]:
-    """Return allowed origins from defaults and the ALLOWED_ORIGINS env var."""
-
-    env_origins = {
-        origin.strip()
-        for origin in os.environ.get("ALLOWED_ORIGINS", "").split(",")
-        if origin.strip()
-    }
-    origins = DEFAULT_ALLOWED_ORIGINS | env_origins
-    if "*" in origins:
-        return ["*"]
-    return sorted(origins)
-
-
-allowed_origins = _get_allowed_origins()
-allow_credentials = "*" not in allowed_origins
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=allowed_origins,
-    allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization"],
-    allow_credentials=allow_credentials,
+    allow_origins=[
+        "https://www.civilespro.com",
+        "https://app.civilespro.com",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
-
-@app.options("/{full_path:path}")
-async def preflight_handler(full_path: str) -> Response:
-    """Return an empty successful response for CORS preflight requests."""
-
-    return Response(status_code=204)
 
 app.include_router(paypal.router)
 app.include_router(downloads.router)

--- a/app/routes/paypal.py
+++ b/app/routes/paypal.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from typing import Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -148,6 +148,13 @@ def _build_download_url(token_id: str) -> str:
 def _json_error(status_code: int, message: str) -> JSONResponse:
     logger.warning("Responding with error %s: %s", status_code, message)
     return JSONResponse(status_code=status_code, content={"message": message})
+
+
+@router.options("/create-order", include_in_schema=False)
+async def options_create_order() -> Response:
+    """Handle CORS preflight requests for the create-order endpoint."""
+
+    return Response(status_code=204)
 
 
 @router.post("/create-order", response_model=CreateOrderResponse)


### PR DESCRIPTION
## Summary
- configure the FastAPI middleware to allow only the Civiles Pro domains with full method/header access
- add an explicit OPTIONS handler for the PayPal create-order endpoint to satisfy preflight requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ce71f33c832c88ff2024f33ed012