### PR TITLE
Update CORS settings to allow Civiles Pro domains

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,16 +12,19 @@ init_db()
 
 app = FastAPI(title="Civiles Pro API", version="1.0.0")
 
+ALLOWED_ORIGINS = [
+    "https://www.civilespro.com",
+    "https://civilespro.com",
+    "https://app.civilespro.com",
+]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "https://www.civilespro.com",
-        "https://app.civilespro.com",
-    ],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
+    allow_methods=["POST", "OPTIONS"],
     allow_headers=["*"],
+    max_age=600,
 )
 
 


### PR DESCRIPTION
## Summary
- expand the FastAPI CORS allow list to cover all Civiles Pro domains used by the frontend
- scope allowed methods and add a cache duration for the CORS preflight response

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9d2efdf00832cb11762ee2076e77a