### PR TITLE
Add gracias redirect page and update plan checkout links

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ import BlogPage from "./pages/BlogPage.jsx"
 import Servicios from "./pages/Servicios.jsx"
 import Planes from "./pages/Planes.jsx"
 import Entrar from "./pages/Entrar.jsx"
+import Gracias from "./pages/Gracias.jsx"
 import { HelmetProvider } from "react-helmet-async"
 
 ReactDOM.createRoot(document.getElementById("root")).render(
@@ -32,6 +33,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
             <Route path="/servicios" element={<Servicios />} />
             <Route path="/planes" element={<Planes />} />
             <Route path="/entrar" element={<Entrar />} />
+            <Route path="/gracias" element={<Gracias />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/pages/Gracias.jsx
+++ b/src/pages/Gracias.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useMemo } from "react"
+import { useLocation } from "react-router-dom"
+
+const formatPlanLabel = (planRaw) => {
+  if (!planRaw) return "desconocido"
+  const normalized = planRaw.replace(/[-_]+/g, " ")
+  return normalized
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+export default function Gracias() {
+  const location = useLocation()
+
+  const { transactionId, planLabel } = useMemo(() => {
+    const search = new URLSearchParams(location.search)
+    const txId =
+      search.get("transactionId") || search.get("id") || search.get("reference") || ""
+    const planParam = search.get("plan") || ""
+    return {
+      transactionId: txId,
+      planLabel: formatPlanLabel(planParam),
+    }
+  }, [location.search])
+
+  useEffect(() => {
+    const planText = planLabel || "desconocido"
+    const codeText = transactionId || "sin código"
+    const message = `Hola CivilesPro, ya pagué. Mi plan es ${planText}. Código Wompi: ${codeText}`
+    const whatsappUrl = `https://wa.me/573127437848?text=${encodeURIComponent(message)}`
+    window.location.replace(whatsappUrl)
+  }, [planLabel, transactionId])
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center bg-white px-4">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <span className="inline-flex h-12 w-12 animate-spin rounded-full border-4 border-emerald-500 border-t-transparent"></span>
+        <p className="text-lg font-medium text-gray-700">Redirigiendo a activación manual…</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/PlataformaPage.jsx
+++ b/src/pages/PlataformaPage.jsx
@@ -388,7 +388,7 @@ function Plans() {
               </div>
 
               <a
-                href="#"
+                href="https://checkout.wompi.co/l/vyKSFA"
                 className="mt-auto inline-flex h-12 w-full items-center justify-center rounded-lg px-5 font-semibold text-white transition-colors"
                 style={{ backgroundColor: "#03a042ff" }}
               >
@@ -436,7 +436,7 @@ function Plans() {
               </div>
 
               <a
-                href="#"
+                href="https://checkout.wompi.co/l/Wcbaj4"
                 className="mt-7 inline-flex h-12 w-full items-center justify-center rounded-lg px-5 font-semibold text-white transition-colors"
                 style={{ backgroundColor: "#03a042ff" }}
               >


### PR DESCRIPTION
## Summary
- create a Gracias page that reads Wompi parameters and redirects users to WhatsApp while showing a loading spinner
- register the /gracias route in the router so the thank-you page is accessible
- update the Plus and Premium annual plan buttons to point to their Wompi checkout URLs

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e079c1dd34832c933b905ca0277b57