### PR TITLE
Configure multi-page build with route-specific Open Graph metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/postbuild.cjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/plataforma.html
+++ b/plataforma.html
@@ -6,17 +6,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       property="og:title"
-      content="Civiles Pro — Plantillas y Herramientas para Obra"
+      content="Plataforma Civiles Pro — Calcula materiales y presupuestos"
     />
     <meta
       property="og:description"
-      content="Compra segura por PayPal las plantillas de Civiles Pro. Entrega inmediata después de pagar. Soporte técnico en todo momento."
+      content="Accede desde cualquier dispositivo. Compra segura por PayPal o Wompi. Activación inmediata y soporte técnico."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.civilespro.com/" />
+    <meta property="og:url" content="https://www.civilespro.com/plataforma" />
     <meta
       property="og:image"
-      content="https://www.civilespro.com/img/og/home-1200x630.jpg"
+      content="https://www.civilespro.com/img/og/plataforma-1200x630.jpg"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -24,17 +24,17 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Civiles Pro — Plantillas y Herramientas para Obra"
+      content="Plataforma Civiles Pro — Calcula materiales y presupuestos"
     />
     <meta
       name="twitter:description"
-      content="Compra segura por PayPal las plantillas de Civiles Pro. Entrega inmediata después de pagar. Soporte técnico en todo momento."
+      content="Acceso web y móvil. Pago seguro, activación inmediata y soporte."
     />
     <meta
       name="twitter:image"
-      content="https://www.civilespro.com/img/og/home-1200x630.jpg"
+      content="https://www.civilespro.com/img/og/plataforma-1200x630.jpg"
     />
-    <title>Civiles Pro — Plantillas y Herramientas para Obra</title>
+    <title>Plataforma Civiles Pro — Calcula materiales y presupuestos</title>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/postbuild.cjs
+++ b/scripts/postbuild.cjs
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+const distDir = path.resolve(__dirname, "..", "dist");
+const plataformaHtml = path.join(distDir, "plataforma.html");
+const plataformaDir = path.join(distDir, "plataforma");
+const plataformaIndex = path.join(plataformaDir, "index.html");
+
+if (!fs.existsSync(plataformaHtml)) {
+  console.warn(
+    "[postbuild] plataforma.html no encontrado, omitiendo movimiento de archivo."
+  );
+  process.exit(0);
+}
+
+fs.mkdirSync(plataformaDir, { recursive: true });
+fs.renameSync(plataformaHtml, plataformaIndex);
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
+import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath, URL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -17,6 +20,14 @@ export default defineConfig({
         target: "https://civilespro.com",
         changeOrigin: true,
         secure: true,
+      },
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, "index.html"),
+        plataforma: path.resolve(__dirname, "plataforma.html"),
       },
     },
   },


### PR DESCRIPTION
## Summary
- add required Open Graph and Twitter card metadata to index.html for the home route
- create plataforma.html with matching structure and platform-specific social metadata
- configure Vite for multi-page builds and add a postbuild script to relocate plataforma assets

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17dc1bf5c832c860ef432a1113701