### PR TITLE
Improve social sharing metadata for Civiles Pro pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://www.civilespro.com/" />
+    <meta
+      name="description"
+      content="Compra segura por PayPal las plantillas de Civiles Pro. Entrega inmediata después de pagar. Soporte técnico en todo momento."
+    />
     <meta
       property="og:title"
       content="Civiles Pro — Plantillas y Herramientas para Obra"
@@ -15,8 +20,17 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.civilespro.com/" />
     <meta property="og:image" content="https://www.civilespro.com/img/og/home-1200x1200.jpg" />
-      <meta property="og:image:width" content="1200" />
+    <meta
+      property="og:image:secure_url"
+      content="https://www.civilespro.com/img/og/home-1200x1200.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="1200" />
+    <meta
+      property="og:image:alt"
+      content="Portada de Civiles Pro con plantillas para obra"
+    />
     <meta property="og:site_name" content="Civiles Pro" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta

--- a/plataforma.html
+++ b/plataforma.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://www.civilespro.com/plataforma" />
+    <meta
+      name="description"
+      content="Accede desde cualquier dispositivo a la Plataforma Civiles Pro. Compra segura por PayPal o Wompi, activación inmediata y soporte técnico."
+    />
     <meta
       property="og:title"
       content="Plataforma Civiles Pro — Calcula materiales y presupuestos"
@@ -18,8 +23,17 @@
       property="og:image"
       content="https://www.civilespro.com/img/og/plataforma-1200x1200.jpg"
     />
+    <meta
+      property="og:image:secure_url"
+      content="https://www.civilespro.com/img/og/plataforma-1200x1200.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="1200" />
+    <meta
+      property="og:image:alt"
+      content="Portada de la plataforma Civiles Pro"
+    />
     <meta property="og:site_name" content="Civiles Pro" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta


### PR DESCRIPTION
## Summary
- add canonical and description metadata to the main landing page and platform entry point
- extend the Open Graph configuration with secure image URLs, MIME type, and alt text to encourage large WhatsApp previews

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c6e1beac832cb91b765e69276520