### PR TITLE
Add static productos landing with Open Graph metadata

### DIFF
--- a/public/productos/index.html
+++ b/public/productos/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>Civiles Pro — Plantillas y Herramientas</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+  <!-- ===== OPEN GRAPH (imagen CUADRADA primero) ===== -->
+  <meta property="og:title" content="Civiles Pro — Plantillas y Herramientas para Obra" />
+  <meta property="og:description" content="Compra segura por PayPal las plantillas de Civiles Pro. Entrega inmediata después de pagar. Soporte técnico en todo momento." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.civilespro.com/productos" />
+
+  <!-- PRIMERA imagen: CUADRADA (manda el preview grande) -->
+  <meta property="og:image" content="https://www.civilespro.com/img/og/home-1200x1200.jpg?v=1" />
+  <meta property="og:image:secure_url" content="https://www.civilespro.com/img/og/home-1200x1200.jpg?v=1" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="1200" />
+  <meta property="og:image:alt" content="Plantillas y herramientas de Civiles Pro" />
+
+  <!-- Imagen secundaria panorámica (fallback) -->
+  <meta property="og:image" content="https://www.civilespro.com/img/og/home-1200x630.jpg?v=1" />
+
+  <meta property="og:site_name" content="Civiles Pro" />
+  <meta property="og:locale" content="es_LA" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Civiles Pro — Plantillas y Herramientas para Obra" />
+  <meta name="twitter:description" content="Compra segura por PayPal las plantillas de Civiles Pro. Entrega inmediata. Soporte técnico en todo momento." />
+  <meta name="twitter:image" content="https://www.civilespro.com/img/og/home-1200x1200.jpg?v=1" />
+
+  <!-- Prevent indexing blockers: Allow bots -->
+  <meta name="robots" content="index,follow" />
+</head>
+<body>
+  <!-- Redirige inmediatamente a la home para usuarios -->
+  <script>
+    // Redirección para navegadores
+    window.location.replace("https://www.civilespro.com/");
+  </script>
+
+  <!-- Fallback para navegadores sin JS -->
+  <noscript>
+    <p>Si no redirige automáticamente, haz clic: <a href="https://www.civilespro.com/">Entrar a Civiles Pro</a></p>
+    <meta http-equiv="refresh" content="1;url=https://www.civilespro.com/" />
+  </noscript>
+</body>
+</html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary
- add a static productos/index.html page that serves the requested Open Graph metadata and immediate redirect to the home page
- ensure crawlers can fetch the page by adding a permissive robots.txt file

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e29d2ae0b0832c8421b2b7c4ce155a